### PR TITLE
Fixes getting explicitly set false values

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,9 @@ exports.toBoolean = function toBoolean(input) {
 
 // Get an env var that has passed validation.
 exports.get = function get(name, defaultVal) {
-    return env[name] || defaultVal;
+    var val = env[name];
+    var found = val !== null && val !== undefined;
+    return found ? val : defaultVal;
 };
 
 // Set an env var, after validating it.

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,11 @@ describe('get()', function() {
         assert.strictEqual(env.get(randomKey), undefined);
         assert.strictEqual(env.get(randomKey, 'defaultStr'), 'defaultStr');
     });
+
+    it('works with explicitly set false values', function() {
+        env.validate({ MYVAR: 'false' }, { MYVAR: {parse: env.toBoolean }});
+        assert.strictEqual(env.get('MYVAR', true), false);
+    });
 });
 
 


### PR DESCRIPTION
Fixes a bug where an explicitly set false boolean value is ignored and instead the 'get' function returns the default value.

E.g. if "MYVAR" was set to "false" and the parser was set to use toBoolean and then "MYVAR" was retrieved like env.get("MYVAR", true) then true was returned when false was expected.
