### PR TITLE
Feature preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,17 +43,19 @@ exports.validate = function validate(envInput, specInput) {
     Object.keys(specInput).forEach(function(k) {
         var itemSpec = specInput[k];
         var inputValue = envInput[k];
-        try {
-            validatedEnv[k] = checkField(k, inputValue, itemSpec);
-        } catch (err) { errors[k] = itemSpec.help || ''; }  // FIXME separate msg for reqd/invalid values
-
+        if (itemSpec.preset && itemSpec.required) {
+            errors[k] = 'Preset conflicts with required';
+            return;
+        }
         if (itemSpec.recommended && inputValue === undefined) {
             recommendedFields[k] = itemSpec.help || '';
         }
-
-        if (itemSpec.default && inputValue === undefined) {
-            validatedEnv[k] = itemSpec.default;
+        if (itemSpec.preset && typeof inputValue === 'undefined') {
+            inputValue = itemSpec.preset;
         }
+        try {
+            validatedEnv[k] = checkField(k, inputValue, itemSpec);
+        } catch (err) { errors[k] = itemSpec.help || ''; }  // FIXME separate msg for reqd/invalid values
     });
 
     // If we are missing required or recommended fields, invoke the corresponding handler:

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,8 @@
 var assert = require('assert');
 var env = require('../index');
 
+var validationErrors = {};
+env.onError = function(e) { validationErrors = e; };
 
 describe('validate()', function() {
     var basicSpec = { REQD: { required: true, help: 'Required variable' },
@@ -12,8 +14,6 @@ describe('validate()', function() {
                       MYBOOL: { parse: env.toBoolean },
                       MYNUM: { parse: env.toNumber }
                     };
-    var validationErrors = {};
-    env.onError = function(e) { validationErrors = e; };
     it('throws an error if a required field is not present', function() {
         env.validate({}, basicSpec);
         assert.strictEqual(Object.keys(validationErrors).length, 1);

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,17 @@ env.onError = function(e) {
     validationErrors = e;
 };
 
+var didSendRecommendations = false;
+var validationRecommendations = {};
+beforeEach(function() {
+    didSendRecommendations = false;
+    validationRecommendations = {};
+});
+env.onRecommend = function(r) {
+    didSendRecommendations = true;
+    validationRecommendations = r;
+};
+
 describe('validate()', function() {
     var basicSpec = { REQD: { required: true, help: 'Required variable' },
                       PARSED: { parse: function(x) { return x + 'foo'; } },
@@ -19,6 +30,8 @@ describe('validate()', function() {
                       WITHDEFAULT: { default: 'defaultvalue' },
                       REGEXVAR: { regex: /number\d/, default: 'number0' },
                       JSONVAR: { parse: JSON.parse },
+                      OPT: { recommended: true, help: 'Recommended'},
+                      PRESET: { preset: 'preset', recommended: true, help: 'Recommended'},
                       MYBOOL: { parse: env.toBoolean },
                       MYNUM: { parse: env.toNumber }
                     };
@@ -85,24 +98,32 @@ describe('validate()', function() {
         assert.strictEqual(myEnv.MYBOOL, true);
     });
 
-    it('sets default values', function() {
-        var env1 = env.validate({ REQD: 'asdf' }, basicSpec);
-        assert.strictEqual(env1.WITHDEFAULT, 'defaultvalue');
-
-        // The default value isn't returned if we specify one:
-        var env2 = env.validate({ REQD: 'asdf', REGEXVAR: 'number7' }, basicSpec);
-        assert.strictEqual(env2.REGEXVAR, 'number7');
-
-        // Passing an invalid value still triggers validation:
-        assert.strictEqual(validationErrors.REGEXVAR, undefined);
-        env.validate({ REQD: 'asdf', REGEXVAR: 'failme' }, basicSpec);
-        assert.strictEqual(validationErrors.REGEXVAR, '');
+    it('sends recommendations for missing and preset variables', function() {
+        env.validate({ REQD: 1 }, basicSpec);
+        assert(Object.keys(validationRecommendations).length >= 1);
+        assert.strictEqual(validationRecommendations.OPT, 'Recommended');
+        assert.strictEqual(validationRecommendations.PRESET, 'Recommended');
+        assert.strictEqual(didSendErrors, false);
     });
 });
 
+describe('conflicting validation rules', function() {
+    var basicSpec = {
+        REQD_PRESET: { preset: 'preset', required: true, help: 'Required'},
+    };
+
+    it('sends an error if a required field also has a preset', function() {
+        env.validate({}, basicSpec);
+        assert.strictEqual(Object.keys(validationErrors).length, 1);
+        assert.strictEqual(validationErrors.REQD_PRESET, 'Preset conflicts with required');
+    });
+})
 
 describe('get()', function() {
-    var basicSpec = { MYVAR: { required: true } };
+    var basicSpec = {
+        MYVAR: { required: true },
+        PRESET: { recommended: true, preset: 'preset' },
+    };
     var randomKey = 'RANDOMKEY123456';
     process.env[randomKey] = 'HELLO MOCHA';
 
@@ -125,6 +146,18 @@ describe('get()', function() {
     it('works with explicitly set false values', function() {
         env.validate({ MYVAR: 'false' }, { MYVAR: {parse: env.toBoolean }});
         assert.strictEqual(env.get('MYVAR', true), false);
+    });
+
+    it('uses the preset if variable is unavailable', function() {
+        env.validate({ MYVAR: 1 }, basicSpec);
+        assert.strictEqual(env.get('PRESET'), 'preset');
+        assert.strictEqual(didSendErrors, false);
+    });
+
+    it('overrides presets with variables from the environment', function() {
+        env.validate({ PRESET: 'override', MYVAR: 1 }, basicSpec);
+        assert.strictEqual(env.get('PRESET'), 'override');
+        assert.strictEqual(didSendErrors, false);
     });
 });
 


### PR DESCRIPTION
I was also working on support for default values. My implementation is a little bit different, but here are some reasons to consider merging:

* This uses "preset" as the key because `default` is a reserved word in JavaScript.
* This reports an error if preset and required are used together.
* This defines (and correctly handles) a test for the case where a preset is also recommended.

If you prefer to use the word `default` instead of preset, I'd be okay with that.