### PR TITLE
Improved tests for default values

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ exports.validate = function validate(envInput, specInput) {
     Object.keys(specInput).forEach(function(k) {
         var itemSpec = specInput[k];
         var inputValue = envInput[k];
+        if (itemSpec.default && itemSpec.required) {
+            errors[k] = 'Preset conflicts with required';
+            return;
+        }
         try {
             validatedEnv[k] = checkField(k, inputValue, itemSpec);
         } catch (err) { errors[k] = itemSpec.help || ''; }  // FIXME separate msg for reqd/invalid values

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,8 @@
 var assert = require('assert');
 var env = require('../index');
 
+var validationErrors = {};
+env.onError = function(e) { validationErrors = e; };
 
 describe('validate()', function() {
     var basicSpec = { REQD: { required: true, help: 'Required variable' },
@@ -12,8 +14,6 @@ describe('validate()', function() {
                       MYBOOL: { parse: env.toBoolean },
                       MYNUM: { parse: env.toNumber }
                     };
-    var validationErrors = {};
-    env.onError = function(e) { validationErrors = e; };
     it('throws an error if a required field is not present', function() {
         env.validate({}, basicSpec);
         assert.strictEqual(Object.keys(validationErrors).length, 1);

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,17 @@ env.onError = function(e) {
     validationErrors = e;
 };
 
+var didSendRecommendations = false;
+var validationRecommendations = {};
+beforeEach(function() {
+    didSendRecommendations = false;
+    validationRecommendations = {};
+});
+env.onRecommend = function(r) {
+    didSendRecommendations = true;
+    validationRecommendations = r;
+};
+
 describe('validate()', function() {
     var basicSpec = { REQD: { required: true, help: 'Required variable' },
                       PARSED: { parse: function(x) { return x + 'foo'; } },
@@ -19,6 +30,7 @@ describe('validate()', function() {
                       WITHDEFAULT: { default: 'defaultvalue' },
                       REGEXVAR: { regex: /number\d/, default: 'number0' },
                       JSONVAR: { parse: JSON.parse },
+                      OPT: { recommended: true, help: 'Recommended' },
                       MYBOOL: { parse: env.toBoolean },
                       MYNUM: { parse: env.toNumber }
                     };
@@ -97,6 +109,13 @@ describe('validate()', function() {
         assert.strictEqual(validationErrors.REGEXVAR, undefined);
         env.validate({ REQD: 'asdf', REGEXVAR: 'failme' }, basicSpec);
         assert.strictEqual(validationErrors.REGEXVAR, '');
+    });
+
+    it('sends recommendations for missing variables', function() {
+        env.validate({ REQD: 1 }, basicSpec);
+        assert(Object.keys(validationRecommendations).length >= 1);
+        assert.strictEqual(validationRecommendations.OPT, 'Recommended');
+        assert.strictEqual(didSendErrors, false);
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -97,15 +97,18 @@ describe('validate()', function() {
         assert.strictEqual(myEnv.MYBOOL, true);
     });
 
-    it('sets default values', function() {
+    it('uses default value if variable is not present', function() {
         var env1 = env.validate({ REQD: 'asdf' }, basicSpec);
         assert.strictEqual(env1.WITHDEFAULT, 'defaultvalue');
+    });
 
+    it('uses environment variable instead of default', function() {
         // The default value isn't returned if we specify one:
         var env2 = env.validate({ REQD: 'asdf', REGEXVAR: 'number7' }, basicSpec);
         assert.strictEqual(env2.REGEXVAR, 'number7');
+    });
 
-        // Passing an invalid value still triggers validation:
+    it('fails validation even if the default value passes', function() {
         assert.strictEqual(validationErrors.REGEXVAR, undefined);
         env.validate({ REQD: 'asdf', REGEXVAR: 'failme' }, basicSpec);
         assert.strictEqual(validationErrors.REGEXVAR, '');

--- a/test/index.js
+++ b/test/index.js
@@ -123,6 +123,17 @@ describe('validate()', function() {
     });
 });
 
+describe('conflicting validation rules', function() {
+    var basicSpec = {
+        REQD_PRESET: { default: 'default', required: true, help: 'Required'},
+    };
+
+    it('sends an error if a required field also has a preset', function() {
+        env.validate({}, basicSpec);
+        assert.strictEqual(Object.keys(validationErrors).length, 1);
+        assert.strictEqual(validationErrors.REQD_PRESET, 'Preset conflicts with required');
+    });
+})
 
 describe('get()', function() {
     var basicSpec = { MYVAR: { required: true } };

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,7 @@ describe('validate()', function() {
     var basicSpec = { REQD: { required: true, help: 'Required variable' },
                       PARSED: { parse: function(x) { return x + 'foo'; } },
                       CHOICEVAR: { choices: ['one', 'two', 'three'] },
-                      WITHDEFAULT: { default: 'defaultvalue' },
+                      WITHDEFAULT: { default: 'defaultvalue', recommended: true, help: 'Recommended' },
                       REGEXVAR: { regex: /number\d/, default: 'number0' },
                       JSONVAR: { parse: JSON.parse },
                       OPT: { recommended: true, help: 'Recommended' },
@@ -118,6 +118,7 @@ describe('validate()', function() {
         env.validate({ REQD: 1 }, basicSpec);
         assert(Object.keys(validationRecommendations).length >= 1);
         assert.strictEqual(validationRecommendations.OPT, 'Recommended');
+        assert.strictEqual(validationRecommendations.WITHDEFAULT, 'Recommended');
         assert.strictEqual(didSendErrors, false);
     });
 });


### PR DESCRIPTION
This PR improves on the tests for `default` values. This is a superset of the changes in #4. Additions include:

- Split test cases into smaller chunks with more descriptive names
- Confirm that onRecommend still triggers even if a default is available
- Test to ensure error output if there are conflicting validation rules (required & default)