### PR TITLE
.gitignore node-modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
It's nice to have a .gitignore to avoid accidentally adding node-modules into the repo.