### PR TITLE
run TravisCI tests on Node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - 0.12


### PR DESCRIPTION
Node v0.12 is available, might as well test against it in Travis CI. Not sure what difference that actually makes.