### PR TITLE
Url parse

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -63,7 +63,8 @@ exports.email = makeValidator(x => {
 exports.url = makeValidator(x => {
     const parsed = require('url').parse(x)
     const isValid = !!(parsed.protocol && parsed.host && parsed.slashes)
-    return isValid ? x : null
+    if (isValid) return x
+    throw new EnvError(`Invalid url: "${x}"`)
 }, 'url')
 
 exports.json = makeValidator(x => {

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -61,8 +61,21 @@ exports.email = makeValidator(x => {
 }, 'email')
 
 exports.url = makeValidator(x => {
-    const parsed = require('url').parse(x)
-    const isValid = !!(parsed.protocol && parsed.host && parsed.slashes)
+    const url = require('url')
+    let isValid;
+
+    if (url.URL) {
+        try {
+            new url.URL(x)
+            isValid = true
+        } catch (e) {
+            isValid = false
+        }
+    } else {
+        const parsed = url.parse(x)
+        isValid = !!(parsed.protocol && parsed.host && parsed.slashes)
+    }
+
     if (isValid) return x
     throw new EnvError(`Invalid url: "${x}"`)
 }, 'url')


### PR DESCRIPTION
This PR does two things (in separate commits)

1. Explicitly throw on invalid URL instead of returning `null`
    1. As this didn't break any tests, I guess passing in `null` to a validator already threw?
2. Use the newly added, spec-compliant, `URL` to check for validity
    1. It's new in Node@7, and is based on the URL spec. See nodejs/node#7448
    2. Whenever support for Node@6 is dropped, it should be the default.
    3. Alternatively, we could import a polyfill in node@6, but that seems overkill