### PR TITLE
Enable usage of envalid in react-native apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,34 @@ so if you have a `.env` file in your project, envalid will read and validate the
 env vars from that file as well.
 
 
+
+## Usage within React Native
+
+Envalid can be used within React Native with a custom reporter. Also the usage of `dotenv` must be disabled by setting `options.dotEnvPath` to `null`.
+
+Instead of `dotenv` [react-native-config](https://www.npmjs.com/package/react-native-config) can be used to read the configuration.
+
+Example:
+
+```js
+const reactNativeConfig = require('react-native-config')
+const rawConfig = reactNativeConfig.default
+
+const validatedConfig = envalid.cleanEnv(
+  rawConfig,
+  {
+    // validators
+  },
+  {
+    dotEnvPath: null,
+    reporter: ({ errors = {}, env = {} }) => {
+      // handle errors
+    },
+  },
+)
+```
+
+
 ## Motivation
 
 http://www.12factor.net/config

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const { EnvError, EnvMissingError, makeValidator,
         bool, num, str, json, url, email } = require('./lib/validators')
-const defaultReporter = require('./lib/reporter')
 
 const extend = (x = {}, y = {}) => Object.assign({}, x, y)
 
@@ -38,8 +37,13 @@ function formatSpecDescription(spec) {
 // Extend an env var object with the values parsed from a ".env"
 // file, whose path is given by the second argument.
 function extendWithDotEnv(inputEnv, dotEnvPath = '.env') {
-    const fs = require('fs')
-    const dotenv = require('dotenv')
+    // fs and dotenv cannot be required inside react-native.
+    // The react-native packager detects the require calls even if they
+    // are not on the top level, so we need to hide them by concatinating
+    // the module names.
+    const fs = require('f'+'s')
+    const dotenv = require('doten'+'v')
+
     let dotEnvBuffer = null
     try {
         dotEnvBuffer = fs.readFileSync(dotEnvPath)
@@ -110,7 +114,7 @@ function cleanEnv(inputEnv, specs = {}, options = {}) {
         output = options.transformer(output)
     }
 
-    const reporter = options.reporter || defaultReporter
+    const reporter = options.reporter || require('./lib/reporter')
     reporter({ errors, env: output })
 
     return Object.freeze(output)


### PR DESCRIPTION
PR for #30

With this change I can use envalid in a react-native app if I set `dotEnvPath: null` and use a custom reporter.