### PR TITLE
Use prettier for style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,105 +1,82 @@
 const [OFF, WARN, ERR] = [0, 1, 2]
 
 module.exports = {
-    extends: "eslint:recommended",
+    extends: 'eslint:recommended',
+    plugins: ['prettier'],
     parserOptions: {
-        "impliedStrict": true,
-        "sourceType": "module",
-        "ecmaVersion": 7
+        impliedStrict: true,
+        sourceType: 'module',
+        ecmaVersion: 7
     },
     env: {
-        "es6": true,
-        "node": true,
-        "browser": true
+        es6: true,
+        node: true,
+        browser: true
     },
     globals: {},
     rules: {
         // Possible errors & best practices
-        "complexity": [WARN, 7],
-        //"consistent-return": ERR,
-        "curly": [ERR, "multi-line"],
-        "dot-notation": WARN,
-        "eqeqeq": [ERR, "allow-null"],
-        "linebreak-style": [ERR, "unix"],
-        "no-empty": WARN,
-        "no-else-return": OFF,
-        "no-extra-bind": ERR,
-        //"no-magic-numbers": [ERR, { "ignore": [0, 1, 2, -1] }],
-        "no-param-reassign": WARN,
-        "no-throw-literal": WARN,
-        "no-warning-comments": WARN,
-        "no-unexpected-multiline": ERR,
-        "radix": [WARN, "as-needed"],
-        "wrap-iife": [WARN, "outside"],
-        "yoda": ERR,
+        complexity: [WARN, 7],
+        // "consistent-return": ERR,
+        'dot-notation': WARN,
+        eqeqeq: [ERR, 'allow-null'],
+        'linebreak-style': [ERR, 'unix'],
+        'no-empty': WARN,
+        'no-else-return': OFF,
+        'no-extra-bind': ERR,
+        // "no-magic-numbers": [ERR, { "ignore": [0, 1, 2, -1] }],
+        'no-param-reassign': WARN,
+        'no-throw-literal': WARN,
+        'no-warning-comments': WARN,
+        'no-unexpected-multiline': ERR,
+        radix: [WARN, 'as-needed'],
+        'wrap-iife': [WARN, 'outside'],
+        yoda: ERR,
 
         // Variables
-        "init-declarations": [WARN, "always"],
-        "no-redeclare": WARN,
-        "no-shadow": WARN,
-        "no-undef-init": ERR,
-        "no-use-before-define": WARN,
+        'init-declarations': [WARN, 'always'],
+        'no-redeclare': WARN,
+        'no-shadow': WARN,
+        'no-undef-init': ERR,
+        'no-use-before-define': WARN,
 
         // Node/commonjs
-        "callback-return": WARN,
-        "handle-callback-err": ERR,
+        'callback-return': WARN,
+        'handle-callback-err': ERR,
 
         // Style
-        "array-bracket-spacing": [ERR, "never"],
-        "block-spacing": ERR,
-        "brace-style": [WARN, "1tbs", { "allowSingleLine": true }],
-        "camelcase": [ERR, { "properties": "never" }],
-        "comma-dangle": OFF,
-        "comma-spacing": ERR,
-        "comma-style": ERR,
-        "eol-last": ERR,
-        "indent": [OFF, 4],       // Definitely want to enable this later
-        //"key-spacing": ERR,
-        "keyword-spacing": ERR,
-        "max-depth": [ERR, 4],
-        "max-len": [WARN, 100, 4, { "ignoreUrls": true, "ignoreComments": true }],
-        "max-nested-callbacks": [WARN, 4],
-        "new-cap": OFF,
-        "no-bitwise": OFF,    // Could enable later, but we do use bitwise ops in a few places
-        "no-case-declarations": OFF,
-        "no-console": WARN,
-        "no-lonely-if": WARN,
-        "no-multiple-empty-lines": [ERR, { "max": 3 }],
-        "no-new-object": ERR,
-        "no-restricted-syntax": [ERR, "WithStatement"],
-        "no-spaced-func": ERR,
-        "no-trailing-spaces": ERR,
-        "no-unneeded-ternary": ERR,
-        "no-unused-vars": [WARN, {"vars": "all", "args": "none"}], // Should be err, but can trigger on commented-out code
-        "object-curly-spacing": [OFF, "always"],
-        "one-var": [WARN, "never"],
-        "operator-linebreak": WARN,
-        "padded-blocks": [WARN, "never"],
-        "quotes": [ERR, "single"],
-        "quote-props": [WARN, "as-needed"],
-        "semi": [ERR, "never"],
-        "semi-spacing": ERR,
-        "space-before-blocks": ERR,
-        "space-before-function-paren": [ERR, "never"],
-        "space-in-parens": ERR,
-        "space-infix-ops": WARN,
-        "spaced-comment": [ERR, "always"],
+        camelcase: [ERR, { properties: 'never' }],
+        'comma-dangle': OFF,
+        'max-depth': [ERR, 4],
+        'max-nested-callbacks': [WARN, 4],
+        'new-cap': OFF,
+        'no-bitwise': OFF, // Could enable later, but we do use bitwise ops in a few places
+        'no-case-declarations': OFF,
+        'no-console': WARN,
+        'no-lonely-if': WARN,
+        'no-new-object': ERR,
+        'no-restricted-syntax': [ERR, 'WithStatement'],
+        'no-unneeded-ternary': ERR,
+        'no-unused-vars': [WARN, { vars: 'all', args: 'none' }], // Should be err, but can trigger on commented-out code
+        'object-curly-spacing': [OFF, 'always'],
+        'one-var': [WARN, 'never'],
+        'spaced-comment': [ERR, 'always'],
 
         // ES6
         // Any rules here set to OFF are things to turn on eventually
-        "arrow-spacing": ERR,
-        "no-confusing-arrow": ERR,
-        "no-const-assign": ERR,
-        "no-dupe-class-members": ERR,
-        "no-var": ERR,
-        "object-shorthand": OFF,
-        "prefer-arrow-callback": OFF,
-        "prefer-const": WARN,
-        "prefer-spread": OFF,
-        "prefer-template": OFF,
+        'no-confusing-arrow': ERR,
+        'no-const-assign': ERR,
+        'no-dupe-class-members': ERR,
+        'no-var': ERR,
+        'object-shorthand': OFF,
+        'prefer-arrow-callback': OFF,
+        'prefer-const': WARN,
+        'prefer-spread': OFF,
+        'prefer-template': OFF,
 
         // JSDoc
-        //"require-jsdoc": OFF,
-        //"valid-jsdoc": WARN
-    },
+        // "require-jsdoc": OFF,
+        // "valid-jsdoc": WARN
+        'prettier/prettier': [ERR, { singleQuote: true, semi: false, printWidth: 100, tabWidth: 4 }]
+    }
 }

--- a/example/env.js
+++ b/example/env.js
@@ -1,10 +1,10 @@
 const envalid = require('..')
 
 module.exports = envalid.cleanEnv(process.env, {
-    HOST:       envalid.host({ default: '127.0.0.1' }),
-    PORT:       envalid.port({ default: 3000, desc: 'The port to start the server on' }),
+    HOST: envalid.host({ default: '127.0.0.1' }),
+    PORT: envalid.port({ default: 3000, desc: 'The port to start the server on' }),
 
     // For this example, the MESSAGE env var will be read from the .env
     // file in this directory (so the default value won't be used):
-    MESSAGE:    envalid.str({ default: 'Hello, world' })
+    MESSAGE: envalid.str({ default: 'Hello, world' })
 })

--- a/index.js
+++ b/index.js
@@ -1,5 +1,16 @@
-const { EnvError, EnvMissingError, makeValidator,
-        bool, num, str, json, url, email, host, port } = require('./lib/validators')
+const {
+    EnvError,
+    EnvMissingError,
+    makeValidator,
+    bool,
+    num,
+    str,
+    json,
+    url,
+    email,
+    host,
+    port
+} = require('./lib/validators')
 
 const extend = (x = {}, y = {}) => Object.assign({}, x, y)
 
@@ -27,7 +38,6 @@ function validateVar({ spec = {}, name, rawValue }) {
     if (value == null) throw new EnvError(`Invalid value for env var "${name}"`)
     return value
 }
-
 
 // Format a string error message for when a required env var is missing
 function formatSpecDescription(spec) {
@@ -61,9 +71,8 @@ function cleanEnv(inputEnv, specs = {}, options = {}) {
     let output = {}
     let defaultNodeEnv = ''
     const errors = {}
-    const env = (options.dotEnvPath !== null)
-        ? extendWithDotEnv(inputEnv, options.dotEnvPath)
-        : inputEnv
+    const env =
+        options.dotEnvPath !== null ? extendWithDotEnv(inputEnv, options.dotEnvPath) : inputEnv
     const varKeys = Object.keys(specs)
 
     // If validation for NODE_ENV isn't specified, use the default validation:
@@ -77,18 +86,19 @@ function cleanEnv(inputEnv, specs = {}, options = {}) {
 
     for (const k of varKeys) {
         const spec = specs[k]
-        const usingDevDefault = (env.NODE_ENV !== 'production') && (spec.hasOwnProperty('devDefault'))
+        const usingDevDefault = env.NODE_ENV !== 'production' && spec.hasOwnProperty('devDefault')
         const devDefault = usingDevDefault ? spec.devDefault : undefined
         let rawValue = env[k]
 
         if (rawValue === undefined) {
-            rawValue = (devDefault === undefined ? spec.default : devDefault)
+            rawValue = devDefault === undefined ? spec.default : devDefault
         }
 
         // Default values can be anything falsy (including an explicitly set undefined), without
         // triggering validation errors:
-        const usingFalsyDefault = ((spec.hasOwnProperty('default')) && (spec.default === rawValue)) ||
-                                  (usingDevDefault && (devDefault === rawValue))
+        const usingFalsyDefault =
+            (spec.hasOwnProperty('default') && spec.default === rawValue) ||
+            (usingDevDefault && devDefault === rawValue)
 
         try {
             if (rawValue === testOnlySymbol) {
@@ -112,14 +122,12 @@ function cleanEnv(inputEnv, specs = {}, options = {}) {
 
     // If we need to run Object.assign() on output, we must do it before the
     // defineProperties() call, otherwise the properties would be lost
-    output = options.strict
-        ? output
-        : extend(env, output)
+    output = options.strict ? output : extend(env, output)
 
     Object.defineProperties(output, {
-        isDev:        { value: (defaultNodeEnv || output.NODE_ENV) === 'development' },
+        isDev: { value: (defaultNodeEnv || output.NODE_ENV) === 'development' },
         isProduction: { value: (defaultNodeEnv || output.NODE_ENV) === 'production' },
-        isTest:       { value: (defaultNodeEnv || output.NODE_ENV) === 'test' }
+        isTest: { value: (defaultNodeEnv || output.NODE_ENV) === 'test' }
     })
 
     if (options.transformer) {
@@ -134,23 +142,31 @@ function cleanEnv(inputEnv, specs = {}, options = {}) {
     return Object.freeze(output)
 }
 
-
 /**
 * Utility function for providing default values only when NODE_ENV=test
 *
 * For more context, see https://github.com/af/envalid/issues/32
 */
 const testOnly = defaultValueForTests => {
-    return process.env.NODE_ENV === 'test'
-        ? defaultValueForTests
-        : testOnlySymbol
+    return process.env.NODE_ENV === 'test' ? defaultValueForTests : testOnlySymbol
 }
 
-
 module.exports = {
-    cleanEnv, makeValidator,                // core API
-    EnvError, EnvMissingError,              // error subclasses
-    testOnly,                               // utility function(s)
-    bool, num, str, json, host, port,       // built-in validators
-    url, email,
+    // core API
+    cleanEnv,
+    makeValidator,
+    // error subclasses
+    EnvError,
+    EnvMissingError,
+    // utility function(s)
+    testOnly,
+    // built-in validators
+    bool,
+    num,
+    str,
+    json,
+    host,
+    port,
+    url,
+    email
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -30,7 +30,9 @@ module.exports = function defaultReporter({ errors = {}, env = {} }) {
         missingVarsOutput.join('\n'),
         chalk.yellow('\n Exiting with error code 1'),
         RULE
-    ].filter(x => !!x).join('\n')
+    ]
+        .filter(x => !!x)
+        .join('\n')
 
     console.error(output)
     process.exit(1)

--- a/lib/strictProxy.js
+++ b/lib/strictProxy.js
@@ -1,6 +1,5 @@
 const meant = require('meant')
 
-
 /**
 * Suggest similar env var(s) if possible; for use when an invalid var is accessed.
 */
@@ -20,28 +19,31 @@ const didYouMean = (scmd, commands) => {
 *
 * @return {Object} - Proxied environment object with get/set traps
 */
-module.exports = (envObj, originalEnv) => new Proxy(envObj, {
-    get(target, name) {
-        // These checks are needed because calling console.log on a
-        // proxy that throws crashes the entire process. This whitelists
-        // the necessary properties for `console.log(envObj)` to work.
-        if (['inspect', Symbol.toStringTag].includes(name)) return envObj[name]
-        if (name.toString() === 'Symbol(util.inspect.custom)') return envObj[name]
+module.exports = (envObj, originalEnv) =>
+    new Proxy(envObj, {
+        get(target, name) {
+            // These checks are needed because calling console.log on a
+            // proxy that throws crashes the entire process. This whitelists
+            // the necessary properties for `console.log(envObj)` to work.
+            if (['inspect', Symbol.toStringTag].includes(name)) return envObj[name]
+            if (name.toString() === 'Symbol(util.inspect.custom)') return envObj[name]
 
-        const varExists = envObj.hasOwnProperty(name)
-        if (!varExists) {
-            if (originalEnv.hasOwnProperty(name)) {
-                throw new ReferenceError(`[envalid] Env var ${name} was accessed but not validated. This var is set in the environment; please add an envalid validator for it.`)
+            const varExists = envObj.hasOwnProperty(name)
+            if (!varExists) {
+                if (originalEnv.hasOwnProperty(name)) {
+                    throw new ReferenceError(
+                        `[envalid] Env var ${name} was accessed but not validated. This var is set in the environment; please add an envalid validator for it.`
+                    )
+                }
+
+                didYouMean(name, Object.keys(envObj))
+                throw new ReferenceError(`[envalid] Env var not found: ${name}`)
             }
 
-            didYouMean(name, Object.keys(envObj))
-            throw new ReferenceError(`[envalid] Env var not found: ${name}`)
+            return envObj[name]
+        },
+
+        set(target, name) {
+            throw new TypeError(`[envalid] Attempt to mutate environment value: ${name}`)
         }
-
-        return envObj[name]
-    },
-
-    set(target, name) {
-        throw new TypeError(`[envalid] Attempt to mutate environment value: ${name}`)
-    },
-})
+    })

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,7 +1,6 @@
 const isFQDN = require('validator/lib/isFQDN')
 const isIP = require('validator/lib/isIP')
-const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/    // intentionally non-exhaustive
-
+const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/ // intentionally non-exhaustive
 
 class EnvError extends TypeError {
     constructor(...args) {
@@ -12,7 +11,6 @@ class EnvError extends TypeError {
 }
 exports.EnvError = EnvError
 
-
 class EnvMissingError extends ReferenceError {
     constructor(...args) {
         super(...args)
@@ -22,8 +20,6 @@ class EnvMissingError extends ReferenceError {
 }
 exports.EnvMissingError = EnvMissingError
 
-
-
 function makeValidator(parseFn, type = 'unknown') {
     return function(spec = {}) {
         spec.type = type
@@ -32,7 +28,6 @@ function makeValidator(parseFn, type = 'unknown') {
     }
 }
 exports.makeValidator = makeValidator
-
 
 exports.bool = makeValidator(input => {
     switch (input) {
@@ -68,17 +63,22 @@ exports.email = makeValidator(x => {
 }, 'email')
 
 exports.host = makeValidator(input => {
-  if (!isFQDN(input, { require_tld: false }) && !isIP(input)) {
-    throw new EnvError(`Invalid host (domain or ip): "${input}"`)
-  }
-  return input
+    if (!isFQDN(input, { require_tld: false }) && !isIP(input)) {
+        throw new EnvError(`Invalid host (domain or ip): "${input}"`)
+    }
+    return input
 }, 'host')
 
 exports.port = makeValidator(input => {
     const coerced = +input
-    if (Number.isNaN(coerced) || `${coerced}` !== input || coerced % 1 !== 0 ||
-          coerced < 1 || coerced > 65535) {
-      throw new EnvError(`Invalid port input: "${input}"`)
+    if (
+        Number.isNaN(coerced) ||
+        `${coerced}` !== input ||
+        coerced % 1 !== 0 ||
+        coerced < 1 ||
+        coerced > 65535
+    ) {
+        throw new EnvError(`Invalid port input: "${input}"`)
     }
     return coerced
 }, 'port')
@@ -110,4 +110,3 @@ exports.json = makeValidator(x => {
         throw new EnvError(`Invalid json: "${x}"`)
     }
 }, 'json')
-

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "engineStrict": true,
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . --ignore-pattern '!.eslintrc.js'",
     "test": "painless -r spec tests/*.js",
     "coverage": "nyc npm test",
     "prepush": "npm run lint && npm test"
@@ -27,10 +27,12 @@
     "validation"
   ],
   "devDependencies": {
-    "eslint": "4.4.1",
+    "eslint": "4.5.0",
+    "eslint-plugin-prettier": "2.2.0",
     "husky": "0.14.3",
     "nyc": "11.1.0",
     "painless": "0.9.5",
+    "prettier": "1.5.3",
     "typescript": "2.4.2",
     "typescript-definition-tester": "0.0.5"
   },

--- a/tests/test_basics.js
+++ b/tests/test_basics.js
@@ -11,14 +11,15 @@ test('string passthrough', () => {
 test('transformer option: allow transformation of keys', () => {
     const lowerCaseKey = (acc, [key, value]) => Object.assign(acc, { [key.toLowerCase()]: value })
     const opts = {
-        transformer: i => Object
-            .keys(i)
-            .map(e => [e, i[e]])
-            .reduce(lowerCaseKey, {})
+        transformer: i => Object.keys(i).map(e => [e, i[e]]).reduce(lowerCaseKey, {})
     }
-    const env = cleanEnv({ FOO: 'bar', FOO_BAR: 'baz' }, {
-        FOO: str()
-    }, opts)
+    const env = cleanEnv(
+        { FOO: 'bar', FOO_BAR: 'baz' },
+        {
+            FOO: str()
+        },
+        opts
+    )
     assert.deepEqual(env, { foo: 'bar', foo_bar: 'baz' })
 })
 
@@ -33,30 +34,42 @@ test('output is immutable', () => {
 })
 
 test('using provided default value', () => {
-    const env = cleanEnv({}, {
-        FOO: str({ default: 'asdf' })
-    })
+    const env = cleanEnv(
+        {},
+        {
+            FOO: str({ default: 'asdf' })
+        }
+    )
     assert.deepEqual(env, { FOO: 'asdf' })
 })
 
 test('default value can be blank', () => {
-    const env = cleanEnv({}, {
-        FOO: str({ default: '' })
-    })
+    const env = cleanEnv(
+        {},
+        {
+            FOO: str({ default: '' })
+        }
+    )
     assert.deepEqual(env, { FOO: '' })
 })
 
 test('default set to undefined', () => {
-    const env = cleanEnv({}, {
-        FOO: str({ default: undefined })
-    })
+    const env = cleanEnv(
+        {},
+        {
+            FOO: str({ default: undefined })
+        }
+    )
     assert.deepEqual(env, { FOO: undefined })
 })
 
 test('devDefault set to undefined', () => {
-    const env = cleanEnv({ NODE_ENV: 'test' }, {
-        FOO: str({ devDefault: undefined })
-    })
+    const env = cleanEnv(
+        { NODE_ENV: 'test' },
+        {
+            FOO: str({ devDefault: undefined })
+        }
+    )
     assert.deepEqual(env, { NODE_ENV: 'test', FOO: undefined })
 })
 
@@ -111,13 +124,20 @@ test('choices field', () => {
     assertPassthrough({ FOO: 'baz' }, spec)
 
     // Throws an error when `choices` is not an array
-    assert.throws(() => cleanEnv({ FOO: 'hi' }, { FOO: str({ choices: 123 }) }, makeSilent),
-                  Error, 'must be an array')
+    assert.throws(
+        () => cleanEnv({ FOO: 'hi' }, { FOO: str({ choices: 123 }) }, makeSilent),
+        Error,
+        'must be an array'
+    )
 })
 
 test('misconfigured spec', () => {
     // Validation throws with different error if spec is invalid
-    assert.throws(() => cleanEnv({ FOO: 'asdf' }, { FOO: {} }, makeSilent), EnvError, 'Invalid spec')
+    assert.throws(
+        () => cleanEnv({ FOO: 'asdf' }, { FOO: {} }, makeSilent),
+        EnvError,
+        'Invalid spec'
+    )
 })
 
 test('NODE_ENV built-in support', () => {
@@ -156,7 +176,7 @@ test('NODE_ENV built-in support', () => {
 test('testOnly', () => {
     const processEnv = process.env.NODE_ENV
     const makeSpec = () => ({
-        FOO: str({devDefault: testOnly('sup')})
+        FOO: str({ devDefault: testOnly('sup') })
     })
 
     // Create an env spec that has our testOnly value applied as the devDefault,
@@ -168,6 +188,12 @@ test('testOnly', () => {
     const env = cleanEnv({ NODE_ENV: 'test' }, testSpec)
     assert.deepEqual(env, { NODE_ENV: 'test', FOO: 'sup' })
 
-    assert.throws(() => cleanEnv({ NODE_ENV: 'production' }, makeSpec(), makeSilent), EnvMissingError)
-    assert.throws(() => cleanEnv({ NODE_ENV: 'development' }, makeSpec(), makeSilent), EnvMissingError)
+    assert.throws(
+        () => cleanEnv({ NODE_ENV: 'production' }, makeSpec(), makeSilent),
+        EnvMissingError
+    )
+    assert.throws(
+        () => cleanEnv({ NODE_ENV: 'development' }, makeSpec(), makeSilent),
+        EnvMissingError
+    )
 })

--- a/tests/test_dotenv.js
+++ b/tests/test_dotenv.js
@@ -3,18 +3,25 @@ const { createGroup, assert } = require('painless')
 const { cleanEnv, str, num } = require('..')
 const test = createGroup()
 
-test.beforeEach(() => fs.writeFileSync('.env', `
+test.beforeEach(() =>
+    fs.writeFileSync(
+        '.env',
+        `
 BAR=asdfasdf
 MYNUM=4
-`))
+`
+    )
+)
 test.afterEach(() => fs.unlinkSync('.env'))
 
-
 test('.env contents are cleaned', () => {
-    const env = cleanEnv({ FOO: 'bar' }, {
-        FOO: str(),
-        MYNUM: num()
-    })
+    const env = cleanEnv(
+        { FOO: 'bar' },
+        {
+            FOO: str(),
+            MYNUM: num()
+        }
+    )
     assert.deepEqual(env, { FOO: 'bar', BAR: 'asdfasdf', MYNUM: 4 })
 })
 

--- a/tests/test_reporter.js
+++ b/tests/test_reporter.js
@@ -9,10 +9,9 @@ test.beforeEach(() => {
     exitSpy = stub(process, 'exit', () => {})
 })
 test.afterEach(() => {
-    console.error.restore()     // eslint-disable-line no-console
+    console.error.restore() // eslint-disable-line no-console
     process.exit.restore()
 })
-
 
 test('reporter', () => {
     reporter({

--- a/tests/test_strict.js
+++ b/tests/test_strict.js
@@ -4,7 +4,6 @@ const { cleanEnv, str, num } = require('..')
 const test = createGroup()
 const strictOption = { strict: true }
 
-
 // assert.deepEqual() substitute for assertions on proxied strict-mode env objects
 // Chai's deepEqual() performs a few checks that the Proxy chokes on, so rather than
 // adding special-case code inside the proxy's get() trap, we use this custom assert
@@ -17,52 +16,83 @@ const objStrictDeepEqual = (actual, desired) => {
     }
 }
 
-test.beforeEach(() => fs.writeFileSync('.env', `
+test.beforeEach(() =>
+    fs.writeFileSync(
+        '.env',
+        `
 BAR=asdfasdf
 MYNUM=4
-`))
+`
+    )
+)
 test.afterEach(() => fs.unlinkSync('.env'))
 
-
 test('strict option: only specified fields are passed through', () => {
-    const env = cleanEnv({ FOO: 'bar', BAZ: 'baz' }, {
-        FOO: str()
-    }, strictOption)
+    const env = cleanEnv(
+        { FOO: 'bar', BAZ: 'baz' },
+        {
+            FOO: str()
+        },
+        strictOption
+    )
     objStrictDeepEqual(env, { FOO: 'bar' })
 })
 
 test('.env test in strict mode', () => {
-    const env = cleanEnv({ FOO: 'bar', BAZ: 'baz' }, {
-        MYNUM: num()
-    }, strictOption)
+    const env = cleanEnv(
+        { FOO: 'bar', BAZ: 'baz' },
+        {
+            MYNUM: num()
+        },
+        strictOption
+    )
     objStrictDeepEqual(env, { MYNUM: 4 })
 })
 
 test('strict mode objects throw when invalid attrs are accessed', () => {
-    const env = cleanEnv({ FOO: 'bar', BAZ: 'baz' }, {
-        FOO: str()
-    }, strictOption)
+    const env = cleanEnv(
+        { FOO: 'bar', BAZ: 'baz' },
+        {
+            FOO: str()
+        },
+        strictOption
+    )
     assert.strictEqual(env.FOO, 'bar')
     assert.throws(() => env.ASDF)
 })
 
 test('strict mode objects throw when attempting to mutate', () => {
-    const env = cleanEnv({ FOO: 'bar', BAZ: 'baz' }, {
-        FOO: str()
-    }, strictOption)
-    assert.throws(() => env.FOO = 'foooooo', '[envalid] Attempt to mutate environment value: FOO')
+    const env = cleanEnv(
+        { FOO: 'bar', BAZ: 'baz' },
+        {
+            FOO: str()
+        },
+        strictOption
+    )
+    assert.throws(() => (env.FOO = 'foooooo'), '[envalid] Attempt to mutate environment value: FOO')
 })
 
 test('strict mode objects throw and suggest add validator if in orig env', () => {
-    const env = cleanEnv({ FOO: 'foo' }, {
-        BAR: str()
-    }, strictOption)
-    assert.throws(() => env.FOO, '[envalid] Env var FOO was accessed but not validated. This var is set in the environment; please add an envalid validator for it.')
+    const env = cleanEnv(
+        { FOO: 'foo' },
+        {
+            BAR: str()
+        },
+        strictOption
+    )
+    assert.throws(
+        () => env.FOO,
+        '[envalid] Env var FOO was accessed but not validated. This var is set in the environment; please add an envalid validator for it.'
+    )
 })
 
 test('strict mode objects throw and suggest typo', () => {
-    const env = cleanEnv({}, {
-        BAR: str()
-    }, strictOption)
+    const env = cleanEnv(
+        {},
+        {
+            BAR: str()
+        },
+        strictOption
+    )
     assert.throws(() => env.BAS, '[envalid] Env var BAS not found, did you mean BAR?')
 })

--- a/tests/test_types.js
+++ b/tests/test_types.js
@@ -1,15 +1,28 @@
 const { createGroup, assert } = require('painless')
-const { cleanEnv, EnvError, makeValidator,
-  str, bool, num, email, host, port, url, json } = require('..')
+const {
+    cleanEnv,
+    EnvError,
+    makeValidator,
+    str,
+    bool,
+    num,
+    email,
+    host,
+    port,
+    url,
+    json
+} = require('..')
 const { assertPassthrough } = require('./utils')
 const test = createGroup()
 const makeSilent = { reporter: null }
 
-
 test('bool() works with various formats', () => {
     assert.equal(bool().type, 'bool')
-    assert.throws(() => cleanEnv({ FOO: 'asfd' }, { FOO: bool() }, makeSilent),
-                  EnvError, 'Invalid value')
+    assert.throws(
+        () => cleanEnv({ FOO: 'asfd' }, { FOO: bool() }, makeSilent),
+        EnvError,
+        'Invalid value'
+    )
 
     const trueBool = cleanEnv({ FOO: true }, { FOO: bool() })
     assert.deepEqual(trueBool, { FOO: true })
@@ -101,7 +114,7 @@ test('port()', () => {
 test('json()', () => {
     assert.equal(json().type, 'json')
     const env = cleanEnv({ FOO: '{"x": 123}' }, { FOO: json() })
-    assert.deepEqual(env, { FOO: {x: 123} })
+    assert.deepEqual(env, { FOO: { x: 123 } })
 
     assert.throws(() => cleanEnv({ FOO: 'abc' }, { FOO: json() }, makeSilent), EnvError)
 })

--- a/tests/test_typescript.js
+++ b/tests/test_typescript.js
@@ -2,10 +2,6 @@ const { createGroup } = require('painless')
 const tt = require('typescript-definition-tester')
 const test = createGroup()
 
-test('Typescript declaration', (done) => {
-    tt.compileDirectory(
-        __dirname,
-        (fileName) => fileName.indexOf('.ts') > -1,
-        () => done()
-    )
+test('Typescript declaration', done => {
+    tt.compileDirectory(__dirname, fileName => fileName.indexOf('.ts') > -1, () => done())
 })


### PR DESCRIPTION
This uses prettier through the eslint plugin to keep the workflow the same.

I removed the conflicting rules from eslintrc, and tried to keep the config they wanted (4 space indent, no semis and 100 char width).