### PR TITLE
Make non-array choices be a TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function validateVar({ spec = {}, name, rawValue }) {
 
     if (spec.choices) {
         if (!Array.isArray(spec.choices)) {
-            throw new Error(`"choices" must be an array (in spec for "${name}")`)
+            throw new TypeError(`"choices" must be an array (in spec for "${name}")`)
         } else if (!spec.choices.includes(value)) {
             throw new EnvError(`Value "${value}" not in choices [${spec.choices}]`)
         }


### PR DESCRIPTION
https://nodejs.org/api/errors.html#errors_class_typeerror

Thoughts on allowing a function which returns `true`/`false` in addition to an array check?

Use case is a `set` validator that returns a `Set` of values, but want to validate the contents to make sure they are all allowed