### PR TITLE
Error types

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function validateVar({ spec = {}, name, rawValue }) {
 
     if (spec.choices) {
         if (!Array.isArray(spec.choices)) {
-            throw new Error(`"choices" must be an array (in spec for "${name}")`)
+            throw new TypeError(`"choices" must be an array (in spec for "${name}")`)
         } else if (!spec.choices.includes(value)) {
             throw new EnvError(`Value "${value}" not in choices [${spec.choices}]`)
         }

--- a/lib/strictProxy.js
+++ b/lib/strictProxy.js
@@ -14,12 +14,12 @@ module.exports = envObj => new Proxy(envObj, {
         if (name.toString() === 'Symbol(util.inspect.custom)') return envObj[name]
 
         const varExists = envObj.hasOwnProperty(name)
-        if (!varExists) throw new Error(`[envalid] Environment var not found: ${name}`)
+        if (!varExists) throw new ReferenceError(`[envalid] Environment var not found: ${name}`)
 
         return envObj[name]
     },
 
     set(name) {
-        throw new Error(`[envalid] Attempt to mutate environment value: ${name}`)
+        throw new TypeError(`[envalid] Attempt to mutate environment value: ${name}`)
     },
 })

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,21 +1,23 @@
 const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/    // intentionally non-exhaustive
 
 
-function EnvError(input) {
-    this.message = input
-    this.stack = new Error().stack
+class EnvError extends TypeError {
+    constructor(...args) {
+        super(...args)
+        Error.captureStackTrace(this, EnvError)
+        this.name = 'EnvError'
+    }
 }
-EnvError.prototype = Object.create(Error.prototype)
-EnvError.prototype.name = 'EnvError'
 exports.EnvError = EnvError
 
 
-function EnvMissingError(input) {
-    this.message = input
-    this.stack = new Error().stack
+class EnvMissingError extends ReferenceError {
+    constructor(...args) {
+        super(...args)
+        Error.captureStackTrace(this, EnvMissingError)
+        this.name = 'EnvMissingError'
+    }
 }
-EnvMissingError.prototype = Object.create(Error.prototype)
-EnvMissingError.prototype.name = 'EnvMissingError'
 exports.EnvMissingError = EnvMissingError
 
 


### PR DESCRIPTION
https://nodejs.org/api/errors.html#errors_class_typeerror

Thoughts on allowing a function which returns `true`/`false` in addition to an array check?

Use case is a `set` validator that returns a `Set` of values, but want to validate the contents to make sure they are all allowed