### PR TITLE
Add host() and port() validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ url, email address). To these ends, the following validation functions are avail
 * `bool()` - Parses env var strings `"0", "1", "true", "false", "t", "f"` into booleans
 * `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number
 * `email()` - Ensures an env var is an email address
+* `host()` - Ensures an env var is either a domain name or an ip address (v4 or v6)
+* `port()` - Ensures an env var is a TCP port (1-65535)
 * `url()` - Ensures an env var is a url with a protocol and hostname
 * `json()` - Parses an env var with `JSON.parse`
 

--- a/example/env.js
+++ b/example/env.js
@@ -1,8 +1,8 @@
 const envalid = require('..')
 
 module.exports = envalid.cleanEnv(process.env, {
-    HOST:       envalid.str({ default: '127.0.0.1' }),
-    PORT:       envalid.num({ default: 3000, desc: 'The port to start the server on' }),
+    HOST:       envalid.host({ default: '127.0.0.1' }),
+    PORT:       envalid.port({ default: 3000, desc: 'The port to start the server on' }),
 
     // For this example, the MESSAGE env var will be read from the .env
     // file in this directory (so the default value won't be used):

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { EnvError, EnvMissingError, makeValidator,
-        bool, num, str, json, url, email } = require('./lib/validators')
+        bool, num, str, json, url, email, host, port } = require('./lib/validators')
 
 const extend = (x = {}, y = {}) => Object.assign({}, x, y)
 
@@ -149,7 +149,8 @@ const testOnly = defaultValueForTests => {
 
 module.exports = {
     cleanEnv, makeValidator,                // core API
-    bool, num, str, json, url, email,       // built-in validators
     EnvError, EnvMissingError,              // error subclasses
-    testOnly                                // utility function(s)
+    testOnly,                               // utility function(s)
+    bool, num, str, json, host, port,       // built-in validators
+    url, email,
 }

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,3 +1,5 @@
+const isFQDN = require('validator/lib/isFQDN')
+const isIP = require('validator/lib/isIP')
 const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/    // intentionally non-exhaustive
 
 
@@ -64,6 +66,22 @@ exports.email = makeValidator(x => {
     if (EMAIL_REGEX.test(x)) return x
     throw new EnvError(`Invalid email address: "${x}"`)
 }, 'email')
+
+exports.host = makeValidator(input => {
+  if (!isFQDN(input, { require_tld: false }) && !isIP(input)) {
+    throw new EnvError(`Invalid host (domain or ip): "${input}"`)
+  }
+  return input
+}, 'host')
+
+exports.port = makeValidator(input => {
+    const coerced = +input
+    if (Number.isNaN(coerced) || `${coerced}` !== input || coerced % 1 !== 0 ||
+          coerced < 1 || coerced > 65535) {
+      throw new EnvError(`Invalid port input: "${input}"`)
+    }
+    return coerced
+}, 'port')
 
 exports.url = makeValidator(x => {
     const url = require('url')

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "chalk": "2.1.0",
     "dotenv": "4.0.0",
-    "meant": "1.0.0"
+    "meant": "1.0.0",
+    "validator": "8.1.0"
   },
   "typings": "envalid.d.ts"
 }


### PR DESCRIPTION
Closes https://github.com/af/envalid/issues/51

I leveraged [validator.js](https://github.com/chriso/validator.js) to avoid writing too much code. Only two files are being required from that module, so the overall library size does not grow by too much for those who decide to use it on the client side. This also opens a door to tens of other custom validators  if there is a need for them in future. Perhaps, `email()` and `url()` could now also be switched to `validator.js` methods, but that's a topic for a different discussion.

Unfortunately, `host()` did not catch two edge cases due to https://github.com/chriso/validator.js/issues/704, so I commented out two lines in the tests. Not crucial for the PR to get merged, but worth noting for future.
