### PR TITLE
Fix tests for host()

### DIFF
--- a/tests/test_types.js
+++ b/tests/test_types.js
@@ -95,11 +95,11 @@ test('port()', () => {
     assert.equal(port().type, 'port')
     const spec = { FOO: port() }
 
-    const with1 = cleanEnv({ FOO: '1' }, { FOO: num() })
+    const with1 = cleanEnv({ FOO: '1' }, spec)
     assert.deepEqual(with1, { FOO: 1 })
-    const with80 = cleanEnv({ FOO: '80' }, { FOO: num() })
+    const with80 = cleanEnv({ FOO: '80' }, spec)
     assert.deepEqual(with80, { FOO: 80 })
-    const with65535 = cleanEnv({ FOO: '65535' }, { FOO: num() })
+    const with65535 = cleanEnv({ FOO: '65535' }, spec)
     assert.deepEqual(with65535, { FOO: 65535 })
 
     assert.throws(() => cleanEnv({ FOO: '' }, spec, makeSilent), EnvError)


### PR DESCRIPTION
Just looked at https://github.com/af/envalid/pull/55 again and noticed a typo in tests. The fix does not change anything now, but might be handy in future.