### PR TITLE
Allow passing in numbers as port

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -73,7 +73,7 @@ exports.port = makeValidator(input => {
     const coerced = +input
     if (
         Number.isNaN(coerced) ||
-        `${coerced}` !== input ||
+        `${coerced}` !== `${input}` ||
         coerced % 1 !== 0 ||
         coerced < 1 ||
         coerced > 65535

--- a/tests/test_types.js
+++ b/tests/test_types.js
@@ -99,6 +99,8 @@ test('port()', () => {
     assert.deepEqual(with1, { FOO: 1 })
     const with80 = cleanEnv({ FOO: '80' }, spec)
     assert.deepEqual(with80, { FOO: 80 })
+    const with80Num = cleanEnv({ FOO: 80 }, spec)
+    assert.deepEqual(with80Num, { FOO: 80 })
     const with65535 = cleanEnv({ FOO: '65535' }, spec)
     assert.deepEqual(with65535, { FOO: 65535 })
 


### PR DESCRIPTION
This allows us to have port as a number in our config.

e.g.:

```js
    PORT: port({
        desc: 'The port to expose the application on',
        default: 3030,
    }),
```

/cc @kachkaev