### PR TITLE
Add port and host validator type definitions

### DIFF
--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -121,3 +121,11 @@ export function url(spec?: Spec<string>): ValidatorSpec<string>
  * Ensures an env var is an email address
  */
 export function email(spec?: Spec<string>): ValidatorSpec<string>
+/**
+ * Ensures an env var is either a domain name or an ip address (v4 or v6)
+ */
+export function host(spec?: Spec<string>): ValidatorSpec<string>
+/**
+ * Ensures an env var is a TCP port (1-65535)
+ */
+export function port(spec?: Spec<number>): ValidatorSpec<number>


### PR DESCRIPTION
Hi, I've noticed that some documented validators are not in the type definitions file.