### PR TITLE
Allow `Symbol.iterator` in strict proxy

### DIFF
--- a/lib/strictProxy.js
+++ b/lib/strictProxy.js
@@ -26,7 +26,7 @@ module.exports = (envObj, originalEnv) =>
             // proxy that throws crashes the entire process. This whitelists
             // the necessary properties for `console.log(envObj)` and
             // `envObj.hasOwnProperty('string')` to work.
-            if (['inspect', 'hasOwnProperty', Symbol.toStringTag].includes(name)) {
+            if (['inspect', 'hasOwnProperty', Symbol.toStringTag, Symbol.iterator].includes(name)) {
                 return envObj[name]
             }
             if (name.toString() === 'Symbol(util.inspect.custom)') return envObj[name]


### PR DESCRIPTION
Without this `console.log(env)` crashes on newer nodes.

I'm unable to write a test that does not output things to the console during the run, but you can test yourself calling `console.log(env)` on node 8.6.