### PR TITLE
Infer return type of cleanEnv from validators

### DIFF
--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -74,11 +74,23 @@ interface CleanOptions {
     dotEnvPath?: string
 }
 
+interface StrictCleanOptions extends CleanOptions {
+    strict: true
+}
+
 /**
- * Returns a sanitized, immutable environment object.
+ * Returns a sanitized, immutable environment object. _Only_ the env vars
+ * specified in the `validators` parameter will be accessible on the returned
+ * object.
  * @param environment An object containing your env vars (eg. process.env).
+ * @param validators An object that specifies the format of required vars.
+ * @param options An object that specifies options for cleanEnv.
  */
-export function cleanEnv<T>(environment: any): Readonly<T> & CleanEnv
+export function cleanEnv<T>(
+    environment: any,
+    validators: { [K in keyof T]: ValidatorSpec<T[K]> },
+    options: StrictCleanOptions
+): Readonly<T> & CleanEnv
 /**
  * Returns a sanitized, immutable environment object.
  * @param environment An object containing your env vars (eg. process.env).
@@ -87,16 +99,9 @@ export function cleanEnv<T>(environment: any): Readonly<T> & CleanEnv
  */
 export function cleanEnv<T>(
     environment: any,
-    validators: { [K in keyof T]: ValidatorSpec<T[K]> },
+    validators?: { [K in keyof T]: ValidatorSpec<T[K]> },
     options?: CleanOptions
-): Readonly<T> & CleanEnv
-/**
- * Returns a sanitized, immutable environment object.
- * @param environment An object containing your env vars (eg. process.env).
- * @param validators An object that specifies the format of required vars.
- * @param options An object that specifies options for cleanEnv.
- */
-export function cleanEnv(environment: any, validators?: Specs, options?: CleanOptions): any
+): Readonly<T> & CleanEnv & { readonly [varName: string]: string }
 
 /**
  * Create your own validator functions.

--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -31,10 +31,6 @@ interface ValidatorSpec<T> extends Spec<T> {
     _parse: (input: string) => T
 }
 
-interface Specs {
-    [key: string]: ValidatorSpec<any>
-}
-
 interface CleanEnv {
     /** true if NODE_ENV === 'development' */
     readonly isDevelopment: boolean

--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -78,7 +78,7 @@ interface CleanOptions {
  * Returns a sanitized, immutable environment object.
  * @param environment An object containing your env vars (eg. process.env).
  */
-export function cleanEnv<T>(environment: any): T & CleanEnv
+export function cleanEnv<T>(environment: any): Readonly<T> & CleanEnv
 /**
  * Returns a sanitized, immutable environment object.
  * @param environment An object containing your env vars (eg. process.env).
@@ -89,7 +89,7 @@ export function cleanEnv<T>(
     environment: any,
     validators: { [K in keyof T]: ValidatorSpec<T[K]> },
     options?: CleanOptions
-): T & CleanEnv
+): Readonly<T> & CleanEnv
 /**
  * Returns a sanitized, immutable environment object.
  * @param environment An object containing your env vars (eg. process.env).

--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -8,7 +8,7 @@ interface Spec<T> {
      */
     default?: T
     /**
-     * A fallback value to use only when NODE_ENV is not 'production'. 
+     * A fallback value to use only when NODE_ENV is not 'production'.
      * This is handy for env vars that are required for production environments, but optional for development and testing.
      */
     devDefault?: T
@@ -77,19 +77,26 @@ interface CleanOptions {
 /**
  * Returns a sanitized, immutable environment object.
  * @param environment An object containing your env vars (eg. process.env).
- * @param validators An object that specifies the format of required vars.
  */
-export function cleanEnv(environment: any, validators?: Specs, options?: CleanOptions): any
+export function cleanEnv<T>(environment: any): T & CleanEnv
 /**
  * Returns a sanitized, immutable environment object.
  * @param environment An object containing your env vars (eg. process.env).
  * @param validators An object that specifies the format of required vars.
+ * @param options An object that specifies options for cleanEnv.
  */
 export function cleanEnv<T>(
     environment: any,
-    validators?: Specs,
+    validators: { [K in keyof T]: ValidatorSpec<T[K]> },
     options?: CleanOptions
 ): T & CleanEnv
+/**
+ * Returns a sanitized, immutable environment object.
+ * @param environment An object containing your env vars (eg. process.env).
+ * @param validators An object that specifies the format of required vars.
+ * @param options An object that specifies options for cleanEnv.
+ */
+export function cleanEnv(environment: any, validators?: Specs, options?: CleanOptions): any
 
 /**
  * Create your own validator functions.

--- a/tests/envalid.ts
+++ b/tests/envalid.ts
@@ -70,7 +70,34 @@ const inferredEnv = cleanEnv(
     }
 )
 
-const inferredUrl: string = inferredEnv.url
+const inferredBool: boolean = inferredEnv.bool
+const valueFromNonStrictCleanEnv: string = inferredEnv.propertyNotDefinedInValidators
+
+const strictEnv = cleanEnv(
+    {},
+    {
+        foo: str({
+            desc: 'description',
+            default: ''
+        }),
+        bool: bool({}),
+        num: num({
+            choices: [1, 2, 3]
+        }),
+        json: json({
+            devDefault: { foo: 'bar' }
+        }),
+        url: url(),
+        email: email({
+            example: 'example',
+            docs: 'http://example.com'
+        })
+    },
+    { strict: true }
+)
+
+const inferredEmail: string = strictEnv.email
+// const invalidField: string = strictEnv.nonsense
 
 // Custom validator
 const validator = makeValidator<Number>((input: string) => 3.33, 'CUSTOM_TYPE')

--- a/tests/envalid.ts
+++ b/tests/envalid.ts
@@ -1,25 +1,29 @@
-import { cleanEnv, makeValidator, str, bool, num, json, url, email, Spec, Specs } from '..';
+import { cleanEnv, makeValidator, str, bool, num, json, url, email, Spec, Specs } from '..'
 
 interface Env {
-    foo: string;
+    foo: string
 }
 
 // Test cleanEnv
-cleanEnv({});
-const env = cleanEnv<Env>({});
-env.foo = '';
-const isDev: Boolean = env.isDev;
-const isProduction: Boolean = env.isProduction;
-const isTest: Boolean = env.isTest;
-cleanEnv({}, {}, {
-    dotEnvPath: null,
-    reporter: (errors, e) => {
-        const errorMessage: string = errors[0].message;
-        const errorName: string = errors[0].name;
-    },
-    strict: false,
-    transformer: (envToTransform) => { }
-})
+cleanEnv({})
+const env = cleanEnv<Env>({})
+typeof env.foo === 'string'
+const isDev: Boolean = env.isDev
+const isProduction: Boolean = env.isProduction
+const isTest: Boolean = env.isTest
+cleanEnv(
+    {},
+    {},
+    {
+        dotEnvPath: null,
+        reporter: (errors, e) => {
+            const errorMessage: string = errors[0].message
+            const errorName: string = errors[0].name
+        },
+        strict: false,
+        transformer: envToTransform => {}
+    }
+)
 
 // Test validator specs
 const spec: Specs = {
@@ -32,7 +36,7 @@ const spec: Specs = {
         choices: [1, 2, 3]
     }),
     json: json({
-        devDefault: { foo: 'bar' },
+        devDefault: { foo: 'bar' }
     }),
     url: url(),
     email: email({
@@ -40,12 +44,13 @@ const spec: Specs = {
         docs: 'http://example.com'
     })
 }
-spec[0]._parse('test');
-spec[0].type === 'test';
-cleanEnv({}, spec);
+spec[0]._parse('test')
+spec[0].type === 'test'
+const inferredEnv = cleanEnv({}, spec)
+typeof inferredEnv.bool === 'boolean'
 
 // Custom validator
-const validator = makeValidator<Number>((input: string) => 3.33, 'CUSTOM_TYPE');
+const validator = makeValidator<Number>((input: string) => 3.33, 'CUSTOM_TYPE')
 validator({
     default: 3.33,
     desc: 'Test Validator'

--- a/tests/envalid.ts
+++ b/tests/envalid.ts
@@ -7,10 +7,10 @@ interface Env {
 // Test cleanEnv
 cleanEnv({})
 const env = cleanEnv<Env>({})
-typeof env.foo === 'string'
-const isDev: Boolean = env.isDev
-const isProduction: Boolean = env.isProduction
-const isTest: Boolean = env.isTest
+const foo: string = env.foo
+const isDev: boolean = env.isDev
+const isProduction: boolean = env.isProduction
+const isTest: boolean = env.isTest
 cleanEnv(
     {},
     {},
@@ -46,8 +46,31 @@ const spec: Specs = {
 }
 spec[0]._parse('test')
 spec[0].type === 'test'
-const inferredEnv = cleanEnv({}, spec)
-typeof inferredEnv.bool === 'boolean'
+cleanEnv({}, spec)
+
+const inferredEnv = cleanEnv(
+    {},
+    {
+        foo: str({
+            desc: 'description',
+            default: ''
+        }),
+        bool: bool({}),
+        num: num({
+            choices: [1, 2, 3]
+        }),
+        json: json({
+            devDefault: { foo: 'bar' }
+        }),
+        url: url(),
+        email: email({
+            example: 'example',
+            docs: 'http://example.com'
+        })
+    }
+)
+
+const inferredUrl: string = inferredEnv.url
 
 // Custom validator
 const validator = makeValidator<Number>((input: string) => 3.33, 'CUSTOM_TYPE')

--- a/tests/envalid.ts
+++ b/tests/envalid.ts
@@ -1,4 +1,4 @@
-import { cleanEnv, makeValidator, str, bool, num, json, url, email, Spec, Specs } from '..'
+import { cleanEnv, makeValidator, str, bool, num, json, url, email, Spec } from '..'
 
 interface Env {
     foo: string
@@ -26,7 +26,7 @@ cleanEnv(
 )
 
 // Test validator specs
-const spec: Specs = {
+const spec = {
     foo: str({
         desc: 'description',
         default: ''
@@ -44,8 +44,8 @@ const spec: Specs = {
         docs: 'http://example.com'
     })
 }
-spec[0]._parse('test')
-spec[0].type === 'test'
+spec.foo._parse('test')
+spec.foo.type === 'test'
 cleanEnv({}, spec)
 
 const inferredEnv = cleanEnv(


### PR DESCRIPTION
TypeScript is pretty cool: we can infer the return type of a function like `cleanEnv` from the validator spec object we pass in without needing to specify the type parameter ourselves. This PR adds an overload in the typedefs that'll make that happen whenever possible.

The typedef for this method could actually be refined even further, allowing an extra indexer property `[var: string]: string` when `strict` is false or undefined in the options (and _only_ the props declared in the validator map when `strict` is true) but this should be good enough for most purposes.