### PR TITLE
Add Array validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const env = envalid.cleanEnv(process.env, {
 })
 
 
-// Read an environment variable, which is validated and cleaned during 
+// Read an environment variable, which is validated and cleaned during
 // and/or filtering that you specified with cleanEnv().
 env.ADMIN_EMAIL     // -> 'admin@example.com'
 
@@ -75,6 +75,7 @@ url, email address). To these ends, the following validation functions are avail
 * `port()` - Ensures an env var is a TCP port (1-65535)
 * `url()` - Ensures an env var is a url with a protocol and hostname
 * `json()` - Parses an env var with `JSON.parse`
+* `array()` - Parses an enn var to an array, splits on `,\s?`
 
 Each validation function accepts an (optional) object with the following attributes:
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const {
     url,
     email,
     host,
-    port
+    port,
+    array
 } = require('./lib/validators')
 
 const extend = (x = {}, y = {}) => Object.assign({}, x, y)
@@ -173,5 +174,6 @@ module.exports = {
     host,
     port,
     url,
-    email
+    email,
+    array
 }

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -83,6 +83,17 @@ exports.port = makeValidator(input => {
     return coerced
 }, 'port')
 
+exports.array = makeValidator(input => {
+    let returnValue = input
+    if (typeof returnValue === 'number') throw new EnvError(`Invalid array value: "${input}"`)
+    if (returnValue === '') return returnValue
+    if (returnValue[0] === '[') returnValue = returnValue.slice(1)
+    if (returnValue[returnValue.length - 1] === ']')
+        returnValue = returnValue.slice(0, returnValue.length - 1)
+    if (returnValue === '') return returnValue
+    return returnValue.split(/,\s?/)
+}, 'array')
+
 exports.url = makeValidator(x => {
     const url = require('url')
     let isValid = false

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -85,7 +85,7 @@ exports.port = makeValidator(input => {
 
 exports.array = makeValidator(input => {
     let returnValue = input
-    if (typeof returnValue === 'number') throw new EnvError(`Invalid array value: "${input}"`)
+    if (typeof returnValue === 'number') throw new EnvError(`Invalid array value: "${returnValue}"`)
     if (returnValue === '') return returnValue
     if (returnValue[0] === '[') returnValue = returnValue.slice(1)
     if (returnValue[returnValue.length - 1] === ']')

--- a/tests/test_types.js
+++ b/tests/test_types.js
@@ -10,7 +10,8 @@ const {
     host,
     port,
     url,
-    json
+    json,
+    array
 } = require('..')
 const { assertPassthrough } = require('./utils')
 const test = createGroup()
@@ -136,6 +137,35 @@ test('str()', () => {
     assert.deepEqual(withEmpty, { FOO: '' })
 
     assert.throws(() => cleanEnv({ FOO: 42 }, { FOO: str() }, makeSilent), EnvError)
+})
+
+test('array()', () => {
+    assert.equal(array().type, 'array')
+    const withEmpty = cleanEnv({ FOO: '' }, { FOO: array() })
+    assert.deepEqual(withEmpty, { FOO: '' })
+
+    const withOnlyBrackets = cleanEnv({ FOO: '[]' }, { FOO: array() })
+    assert.deepEqual(withOnlyBrackets, { FOO: '' })
+
+    const withOpeningBracket = cleanEnv({ FOO: '[test, otherTest' }, { FOO: array() })
+    assert.deepEqual(withOpeningBracket, { FOO: ['test', 'otherTest'] })
+
+    const withClosingBracket = cleanEnv({ FOO: 'test, otherTest]' }, { FOO: array() })
+    assert.deepEqual(withClosingBracket, { FOO: ['test', 'otherTest'] })
+
+    const withBracketInValue = cleanEnv({ FOO: 'te[st, other]Test' }, { FOO: array() })
+    assert.deepEqual(withBracketInValue, { FOO: ['te[st', 'other]Test'] })
+
+    const withBrackets = cleanEnv({ FOO: '[test, otherTest]' }, { FOO: array() })
+    assert.deepEqual(withBrackets, { FOO: ['test', 'otherTest'] })
+
+    const withoutSpace = cleanEnv({ FOO: '[test,otherTest]' }, { FOO: array() })
+    assert.deepEqual(withoutSpace, { FOO: ['test', 'otherTest'] })
+
+    const withoutBrackets = cleanEnv({ FOO: 'test, otherTest' }, { FOO: array() })
+    assert.deepEqual(withoutBrackets, { FOO: ['test', 'otherTest'] })
+
+    assert.throws(() => cleanEnv({ FOO: 42 }, { FOO: array() }, makeSilent), EnvError)
 })
 
 test('custom types', () => {


### PR DESCRIPTION
Hi there!
Thanks for the package, great work and very easy to build upon! :+1:

Personally I missed an Array type, so I added one.
When used it should normalise an comma separated string with or without spaces and return an array with strings.

This is not really related to any issue, just figured this would be a good addition to all the other validators there already is.