### PR TITLE
Fix reporter interface type

### DIFF
--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -44,6 +44,11 @@ interface CleanEnv {
     readonly isProd: boolean
 }
 
+interface ReporterOptions {
+    errors: { [key: string]: Error }
+    env: any
+}
+
 interface CleanOptions {
     /**
      * If true, the output of cleanEnv will only contain the env vars that were specified in the validators argument.
@@ -55,7 +60,7 @@ interface CleanOptions {
      * Pass in a function to override the default error handling and console output.
      * See lib/reporter.js for the default implementation.
      */
-    reporter?: (errors: { [key: string]: Error }, env: any) => void
+    reporter?: (opts: ReporterOptions) => void
 
     /**
      * A function used to transform the cleaned environment object before it is returned from cleanEnv.

--- a/tests/envalid.ts
+++ b/tests/envalid.ts
@@ -16,7 +16,7 @@ cleanEnv(
     {},
     {
         dotEnvPath: null,
-        reporter: (errors, e) => {
+        reporter: ({ errors, env: e }) => {
             const errorMessage: string = errors[0].message
             const errorName: string = errors[0].name
         },


### PR DESCRIPTION
The implementation of reporter expects an object with the keys `error` and `env`, not an argument list. 

- https://github.com/af/envalid/blob/master/lib/reporter.js#L6
- https://github.com/af/envalid/blob/master/tests/test_reporter.js#L17-L20