### PR TITLE
Fix CleanOptions.dotEnvPath type to allow null

### DIFF
--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -67,7 +67,7 @@ interface CleanOptions {
      * Pass null if you want to skip dotenv processing entirely and only load from process.env.
      * @default ".env"
      */
-    dotEnvPath?: string
+    dotEnvPath?: string | null
 }
 
 interface StrictCleanOptions extends CleanOptions {


### PR DESCRIPTION
Otherwise TS may say:

```
[ts]
Argument of type '{ dotEnvPath: string | null; }' is not assignable to parameter of type 'CleanOptions'.     
  Types of property 'dotEnvPath' are incompatible.
    Type 'string | null' is not assignable to type 'string | undefined'.
      Type 'null' is not assignable to type 'string | undefined'.
```

... since `dotEnvPath?: string` only defines `string | undefined` instead of `string | null | undefined` [as is mentioned in the docs](https://github.com/af/envalid/blob/master/README.md#api) and [in the code](https://github.com/af/envalid/blob/95aa0dc649d9fc0bd4c35b6da2888e6bcf4a0cbe/index.js#L75).