### PR TITLE
Change type definitions for env

### DIFF
--- a/envalid.d.ts
+++ b/envalid.d.ts
@@ -42,11 +42,13 @@ interface CleanEnv {
     /** true if NODE_ENV === 'production' */
     readonly isProduction: boolean
     readonly isProd: boolean
+
+    readonly [key: string]: string | object | number | boolean | undefined
 }
 
 interface ReporterOptions {
     errors: { [key: string]: Error }
-    env: any
+    env: CleanEnv
 }
 
 interface CleanOptions {
@@ -65,7 +67,7 @@ interface CleanOptions {
     /**
      * A function used to transform the cleaned environment object before it is returned from cleanEnv.
      */
-    transformer?: (env: any) => any
+    transformer?: (env: CleanEnv) => CleanEnv
 
     /**
      * Path to the file that is parsed by dotenv to optionally load more env vars at runtime.
@@ -88,7 +90,7 @@ interface StrictCleanOptions extends CleanOptions {
  * @param options An object that specifies options for cleanEnv.
  */
 export function cleanEnv<T>(
-    environment: any,
+    environment: NodeJS.ProcessEnv,
     validators: { [K in keyof T]: ValidatorSpec<T[K]> },
     options: StrictCleanOptions
 ): Readonly<T> & CleanEnv
@@ -99,10 +101,10 @@ export function cleanEnv<T>(
  * @param options An object that specifies options for cleanEnv.
  */
 export function cleanEnv<T>(
-    environment: any,
+    environment: NodeJS.ProcessEnv,
     validators?: { [K in keyof T]: ValidatorSpec<T[K]> },
     options?: CleanOptions
-): Readonly<T> & CleanEnv & { readonly [varName: string]: string }
+): Readonly<T> & CleanEnv
 
 /**
  * Create your own validator functions.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "eslint": "4.19.1",
     "eslint-plugin-prettier": "2.6.0",
+    "@types/node": "^10.0.6",
     "husky": "0.14.3",
     "lint-staged": "7.1.0",
     "nyc": "11.7.3",

--- a/tests/envalid.ts
+++ b/tests/envalid.ts
@@ -21,7 +21,7 @@ cleanEnv(
             const errorName: string = errors[0].name
         },
         strict: false,
-        transformer: envToTransform => {}
+        transformer: envToTransform => envToTransform
     }
 )
 
@@ -71,7 +71,7 @@ const inferredEnv = cleanEnv(
 )
 
 const inferredBool: boolean = inferredEnv.bool
-const valueFromNonStrictCleanEnv: string = inferredEnv.propertyNotDefinedInValidators
+const valueFromNonStrictCleanEnv = inferredEnv.propertyNotDefinedInValidators
 
 const strictEnv = cleanEnv(
     {},


### PR DESCRIPTION
closes #82 

Presently have a failing test with this change, though:

`Semantic: ~/Code/neezer/envalid/node_modules/@types/node/index.d.ts (6202,55): Cannot find name 'Map'.`

@af would love a little help with that one.