### PR TITLE
Add additional validator configuration, update str/num validators to include range checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ url, email address). To these ends, the following validation functions are avail
 
 * `str()` - Passes string values through, will ensure an value is present unless a
           `default` value is given. Note that an empty string is considered a valid value -
-          if this is undesirable you can easily create your own validator (see below)
+          if this is undesirable you can easily create your own validator (see below). You can also specify `config` values of `minLength` and `maxLength` to check string length.
 * `bool()` - Parses env var strings `"0", "1", "true", "false", "t", "f"` into booleans
 * `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number. Can specify `config` values of `min` and `max` to validate range.
 * `email()` - Ensures an env var is an email address

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ url, email address). To these ends, the following validation functions are avail
           `default` value is given. Note that an empty string is considered a valid value -
           if this is undesirable you can easily create your own validator (see below)
 * `bool()` - Parses env var strings `"0", "1", "true", "false", "t", "f"` into booleans
-* `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number
+* `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number. Can specify `config` values of `min` and `max` to validate range.
 * `email()` - Ensures an env var is an email address
 * `host()` - Ensures an env var is either a domain name or an ip address (v4 or v6)
 * `port()` - Ensures an env var is a TCP port (1-65535)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Each validation function accepts an (optional) object with the following attribu
 * `desc` - A string that describes the env var.
 * `example` - An example value for the env var.
 * `docs` - A url that leads to more detailed documentation about the env var.
+* `config` - Additional validation configuration that will be passed to the validator (e.g. min length of a string).
 
 
 ## Custom validators

--- a/src/envalid.d.ts
+++ b/src/envalid.d.ts
@@ -24,6 +24,10 @@ interface Spec<T> {
      * A url that leads to more detailed documentation about the env var.
      */
     docs?: string
+    /**
+     * Additional configuration to pass to the validator
+     */
+    config?: any
 }
 
 interface ValidatorSpec<T> extends Spec<T> {
@@ -125,6 +129,10 @@ export function bool(spec?: Spec<boolean>): ValidatorSpec<boolean>
  * Parses an env var (eg. "42", "0.23", "1e5") into a Number.
  */
 export function num(spec?: Spec<number>): ValidatorSpec<number>
+/**
+ * Parses an env var (eg. "42", "0.23", "1e5") into a Number and validates range.
+ */
+export function range(spec?: Spec<number>): ValidatorSpec<number>
 /**
  * Passes string values through, will ensure an value is present unless a default value is given.
  */

--- a/src/envalidWithoutDotenv.js
+++ b/src/envalidWithoutDotenv.js
@@ -25,7 +25,7 @@ function validateVar({ spec = {}, name, rawValue }) {
     if (typeof spec._parse !== 'function') {
         throw new EnvError(`Invalid spec for "${name}"`)
     }
-    const value = spec._parse(rawValue)
+    const value = spec._parse(rawValue, spec.config)
 
     if (spec.choices) {
         if (!Array.isArray(spec.choices)) {

--- a/src/validators.js
+++ b/src/validators.js
@@ -58,8 +58,16 @@ exports.num = makeValidator((input, config = {}) => {
     return coerced
 }, 'num')
 
-exports.str = makeValidator(input => {
-    if (typeof input === 'string') return input
+exports.str = makeValidator((input, config = {}) => {
+    const minLength = config.minLength
+    const maxLength = config.maxLength
+    if (typeof input === 'string') {
+        if (minLength && input.length < minLength)
+            throw new EnvError(`String length less than min (${minLength}): "${input.length}"`)
+        if (maxLength && input.length > maxLength)
+            throw new EnvError(`String length grather than max (${maxLength}): "${input.length}"`)
+        return input
+    }
     throw new EnvError(`Not a string: "${input}"`)
 }, 'str')
 

--- a/src/validators.js
+++ b/src/validators.js
@@ -46,9 +46,15 @@ exports.bool = makeValidator(input => {
     }
 }, 'bool')
 
-exports.num = makeValidator(input => {
+exports.num = makeValidator((input, config = {}) => {
     const coerced = +input
+    const min = +config.min
+    const max = +config.max
+
     if (Number.isNaN(coerced)) throw new EnvError(`Invalid number input: "${input}"`)
+
+    if (min && coerced < min) throw new EnvError(`Number less than min (${min}): "${input}"`)
+    if (max && coerced > max) throw new EnvError(`Number greater than max (${max}): "${input}"`)
     return coerced
 }, 'num')
 

--- a/tests/test_types.js
+++ b/tests/test_types.js
@@ -62,6 +62,21 @@ test('num()', () => {
     const withZero = cleanEnv({ FOO: 0 }, { FOO: num() })
     assert.deepEqual(withZero, { FOO: 0 })
 
+    const withRange = cleanEnv({ FOO: '3' }, { FOO: num({ min: 1, max: 5 }) })
+    assert.deepEqual(withRange, { FOO: 3 })
+
+    // max range fails
+    assert.throws(
+        () => cleanEnv({ FOO: '6' }, { FOO: num({ config: { min: 1, max: 5 } }) }, makeSilent),
+        EnvError
+    )
+
+    // min range fails
+    assert.throws(
+        () => cleanEnv({ FOO: '0' }, { FOO: num({ config: { min: 1, max: 5 } }) }, makeSilent),
+        EnvError
+    )
+
     assert.throws(() => cleanEnv({ FOO: 'asdf' }, { FOO: num() }, makeSilent), EnvError)
 })
 

--- a/tests/test_types.js
+++ b/tests/test_types.js
@@ -151,6 +151,34 @@ test('str()', () => {
     assert.deepEqual(withEmpty, { FOO: '' })
 
     assert.throws(() => cleanEnv({ FOO: 42 }, { FOO: str() }, makeSilent), EnvError)
+
+    const withValidLength = cleanEnv(
+        { FOO: 'just right' },
+        { FOO: str({ minLength: 1, maxLength: 12 }) }
+    )
+    assert.deepEqual(withValidLength, { FOO: 'just right' })
+
+    // maxLength fails
+    assert.throws(
+        () =>
+            cleanEnv(
+                { FOO: 'more than five characters' },
+                { FOO: str({ config: { minLength: 1, maxLength: 5 } }) },
+                makeSilent
+            ),
+        EnvError
+    )
+
+    // minLength fails
+    assert.throws(
+        () =>
+            cleanEnv(
+                { FOO: 'no' },
+                { FOO: str({ config: { minLength: 5, maxLength: 10 } }) },
+                makeSilent
+            ),
+        EnvError
+    )
 })
 
 test('custom types', () => {


### PR DESCRIPTION
Thanks for sharing this library!

This PR adds support for arbitrary validator configuration. There are cases where people may want to add additional configuration to a custom validator such as minimum length or number ranges.

To add this support to a validator simply do this:

```
const fooValidator = makeValidator((x, config = {}) => {
    if (config.foo && x == foo) throw new Error(`cannot equal ${config.foo}`)
    return x
})
```

In addition I have updated the `num()` and `str()` validators to include additional range checks (if provided):

Strings:
```
cleanEnv(
    { FOO: 'just right' },
    { FOO: str({ minLength: 1, maxLength: 12 }) }
)
```

Numbers:
```
cleanEnv(
    { FOO: '4' },
    { FOO: num({ min: 1, max: 12 }) }
)
```