### PR TITLE
Change spec types to allow ReadonlyArray choices

### DIFF
--- a/src/envalid.d.ts
+++ b/src/envalid.d.ts
@@ -2,7 +2,7 @@ interface Spec<T> {
     /**
      * An Array that lists the admissable parsed values for the env var.
      */
-    choices?: T[]
+    choices?: ReadonlyArray<T>
     /**
      * A fallback value, which will be used if the env var wasn't specified. Providing a default effectively makes the env var optional.
      */


### PR DESCRIPTION
In TypeScript, the current type definitions don't allow the following:

```ts
const myChoices: ReadonlyArray<string> = ['foo', 'bar'];
const myEnv = cleanEnv(process.env, { MY_ENV_VAR: str({choices: myChoices});

// Error:(...) TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'any[]'.
```

Given that the `choices` field doesn't need to be modified (only the `include` method is used currently), it should be allowed to be a `ReadonlyArray`. Generally in TS, it’s good practice to use `ReadonlyArray` over `Array` when no mutation is intended. 

Any `Array<T>` is also assignable to `ReadonlyArray<T>`, so this change doesn't break any existing behaviour.

This change uses `ReadonlyArray<T>` instead of `readonly T[]` to maintain compatibility with TS <3.x.

