### PR TITLE
Stricter return type for makeValidator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 npm-debug.log
+yarn-error.log

--- a/src/envalid.d.ts
+++ b/src/envalid.d.ts
@@ -113,7 +113,7 @@ export function cleanEnv<T>(
  * Create your own validator functions.
  */
 export function makeValidator<T>(
-    parser: (input: string) => any,
+    parser: (input: string) => T,
     type?: string
 ): (spec?: Spec<T>) => ValidatorSpec<T>
 

--- a/tests/envalid.ts
+++ b/tests/envalid.ts
@@ -100,8 +100,25 @@ const inferredEmail: string = strictEnv.email
 // const invalidField: string = strictEnv.nonsense
 
 // Custom validator
-const validator = makeValidator<Number>((input: string) => 3.33, 'CUSTOM_TYPE')
-validator({
+const validator = makeValidator<number>((input: string) => 3.33, 'CUSTOM_TYPE')
+const validatorSpec = validator({
     default: 3.33,
     desc: 'Test Validator'
 })
+const shouldBeNum: number = validatorSpec._parse('3')
+// const shouldNotBeString: string = validatorSpec._parse('56')
+
+function isArrayOfStrings(arr: any[]): arr is string[] {
+    return arr.every(s => typeof s === 'string')
+}
+
+const validatorThatThrows = makeValidator<string[]>((input: string) => {
+    const arrStr = JSON.parse(input)
+    if (!Array.isArray(arrStr)) throw new Error('Should be an array!')
+    if (!isArrayOfStrings(arrStr)) {
+        throw new Error('Should be strings!')
+    }
+    return arrStr
+}, 'CUSTOM_TYPE')
+
+// const badValidator = makeValidator<number>((input: string) => '3.33', 'CUSTOM_TYPE')


### PR DESCRIPTION
This PR makes the return type for `makeValidator` stricter, helping to ensure that you're returning a value from the validator that at least looks right.

The caveat here is that `JSON.parse` returns `any`, so if that's your first step you'll have to use something like a user-defined typeguard (see `isArrayOfStrings` helper added to test file) to further refine the type if you want TS to catch anything. But this should still help if, say, you write `makeValidator<number>(....)` and try to `return new Date(....)` at the end of it.