### PR TITLE
Change JSON validator type to allow for stricter types

### DIFF
--- a/src/envalid.d.ts
+++ b/src/envalid.d.ts
@@ -132,7 +132,7 @@ export function str(spec?: Spec<string>): ValidatorSpec<string>
 /**
  * Parses an env var with JSON.parse.
  */
-export function json(spec?: Spec<any>): ValidatorSpec<any>
+export function json<T = any>(spec?: Spec<T>): ValidatorSpec<T>
 /**
  * Ensures an env var is a url with a protocol and hostname
  */


### PR DESCRIPTION
Add the ability to specify stricter types for JSON. This does no runtime type check, only compile time checks.

This is a non breaking change as the generic still uses an ```any``` as default. 