### PR TITLE
chore: make example bool input order in readme consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ url, email address). To these ends, the following validation functions are avail
 * `str()` - Passes string values through, will ensure an value is present unless a
           `default` value is given. Note that an empty string is considered a valid value -
           if this is undesirable you can easily create your own validator (see below)
-* `bool()` - Parses env var strings `"0", "1", "true", "false", "t", "f"` into booleans
+* `bool()` - Parses env var strings `"1", "0", "true", "false", "t", "f"` into booleans
 * `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number
 * `email()` - Ensures an env var is an email address
 * `host()` - Ensures an env var is either a domain name or an ip address (v4 or v6)


### PR DESCRIPTION
This confused me for a little bit, as the order seemed to indicate that `"0"` would be parsed as `true` since the rest of the example goes true, false, true, false.