### PR TITLE
Sort reported items

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -26,8 +26,8 @@ module.exports = function defaultReporter({ errors = {}, env = {} }) {
 
     const output = [
         RULE,
-        invalidVarsOutput.join('\n'),
-        missingVarsOutput.join('\n'),
+        invalidVarsOutput.sort().join('\n'),
+        missingVarsOutput.sort().join('\n'),
         chalk.yellow('\n Exiting with error code 1'),
         RULE,
     ]


### PR DESCRIPTION
Ordering items simplify the way we read the output, useful to know where to search an item in a really long list