### PR TITLE
Handle empty numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 npm-debug.log
 yarn-error.log
+dist

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -56,7 +56,7 @@ export function bool<T extends boolean = boolean>(spec?: Spec<T>) {
 
 export function num<T extends number = number>(spec?: Spec<T>) {
   return makeValidator((input: string) => {
-    const coerced = +input
+    const coerced = parseFloat(input)
     if (Number.isNaN(coerced)) throw new EnvError(`Invalid number input: "${input}"`)
     return coerced
   })(spec)

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -46,6 +46,8 @@ test('num()', () => {
   expect(withZero).toEqual({ FOO: 0 })
 
   expect(() => cleanEnv({ FOO: 'asdf' }, { FOO: num() }, makeSilent)).toThrow()
+
+  expect(() => cleanEnv({ FOO: '' }, { FOO: num() }, makeSilent)).toThrow()
 })
 
 test('email()', () => {


### PR DESCRIPTION
The num() validators considers empty string as valid numbers because `+""`  result in 0, while `parseFloat("")` results in NaN