### PR TITLE
Ensure default values don't go through validation, fix type narrowing from defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each validation function accepts an (optional) object with the following attribu
 * `choices` - An Array that lists the admissable parsed values for the env var.
 * `default` - A fallback value, which will be present in the output if the env var wasn't specified.
               Providing a default effectively makes the env var optional. Note that `default`
-              values are not passed through validation logic.
+              values are not passed through validation logic, they are default *output* values.
 * `devDefault` - A fallback value to use *only* when `NODE_ENV` is _not_ `'production'`. This is handy
                  for env vars that are required for production environments, but optional
                  for development and testing.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,13 @@
+// Hacky conditional type to prevent default/devDefault from narrowing type T to a single value.
+// Ideally this could be replaced by something that would enforce the default value being a subset
+// of T, without affecting the definition of T itself
+type DefaultType<T> =
+  T extends string ? string :
+  T extends number ? number :
+  T extends boolean ? boolean :
+  T extends object ? object :
+  any
+
 export interface Spec<T> {
   /**
    * An Array that lists the admissable parsed values for the env var.
@@ -6,12 +16,12 @@ export interface Spec<T> {
   /**
    * A fallback value, which will be used if the env var wasn't specified. Providing a default effectively makes the env var optional.
    */
-  default?: T
+  default?: DefaultType<T>
   /**
    * A fallback value to use only when NODE_ENV is not 'production'.
    * This is handy for env vars that are required for production environments, but optional for development and testing.
    */
-  devDefault?: T
+  devDefault?: DefaultType<T>
   /**
    * A string that describes the env var.
    */

--- a/tests/basics.test.ts
+++ b/tests/basics.test.ts
@@ -120,17 +120,23 @@ test('choices field', () => {
 test('choices should refine the type of the field to a union', () => {
   type NodeEnvType = 'production' | 'test' | 'development'
 
-  const spec = cleanEnv({ NODE_ENV: 'test' }, {
-    NODE_ENV: str({ choices: ['production', 'test', 'development'] }),
-  })
+  const env = cleanEnv(
+    { NODE_ENV: 'test' },
+    {
+      NODE_ENV: str({ choices: ['production', 'test', 'development'] }),
+      WITH_DEFAULT: str({ choices: ['production', 'test', 'development'], default: 'production' }),
+    },
+  )
 
   // type of the output should be the union type, not the more generic `string`
-  const nodeEnv: NodeEnvType = spec.NODE_ENV
+  const nodeEnv: NodeEnvType = env.NODE_ENV
+  const withDefault: NodeEnvType = env.WITH_DEFAULT
 
   // @ts-expect-error specifying a type that doesn't match the choices union type should cause an error
-  const shouldFail: 'test' | 'wrong' = spec.NODE_ENV
+  const shouldFail: 'test' | 'wrong' = env.NODE_ENV
 
   expect(nodeEnv).toEqual('test')
+  expect(withDefault).toEqual('production')
 })
 
 test('misconfigured spec', () => {

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -96,6 +96,11 @@ test('json()', () => {
   expect(env).toEqual({ FOO: { x: 123 } })
 
   expect(() => cleanEnv({ FOO: 'abc' }, { FOO: json() }, makeSilent)).toThrow()
+
+  // default value should be passed through without running through JSON.parse()
+  expect(cleanEnv({}, {
+    FOO: json({ default: { x: 999 } })
+  })).toEqual({ FOO: { x: 999 } })
 })
 
 test('url()', () => {


### PR DESCRIPTION
2 fixes:
* Default values are currently being passed through validators, and this actually breaks the json validator because it's calling JSON.parse() on an object. Probably a regression in v7
* The changes in #146 are nice for having more specific union/literal types when possible (eg when using `choices`). However it appears to have caused a regression where providing a default value would cause the inferred output type to be that literal value rather than a broader type like `string`. The fix here is kinda hacky but should be suitable for most use cases. `choices` still causes the output type to be narrowed to a union type of its possible options