### PR TITLE
fix: validator spec functions return their generic type

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -37,7 +37,7 @@ export const makeValidator = <T>(parseFn: (input: string) => T) => {
 // that enables better type inference. For more context, check out the following PR:
 // https://github.com/af/envalid/pull/118
 export function bool<T extends boolean = boolean>(spec?: Spec<T>) {
-  return makeValidator((input: string | boolean) => {
+  return makeValidator<T>((input: string | boolean) => {
     switch (input) {
       case true:
       case 'true':
@@ -56,7 +56,7 @@ export function bool<T extends boolean = boolean>(spec?: Spec<T>) {
 }
 
 export function num<T extends number = number>(spec?: Spec<T>) {
-  return makeValidator((input: string) => {
+  return makeValidator<T>((input: string) => {
     const coerced = parseFloat(input)
     if (Number.isNaN(coerced)) throw new EnvError(`Invalid number input: "${input}"`)
     return coerced as T
@@ -64,21 +64,21 @@ export function num<T extends number = number>(spec?: Spec<T>) {
 }
 
 export function str<T extends string = string>(spec?: Spec<T>) {
-  return makeValidator((input: string) => {
+  return makeValidator<T>((input: string) => {
     if (typeof input === 'string') return input as T
     throw new EnvError(`Not a string: "${input}"`)
   })(spec)
 }
 
 export function email<T extends string = string>(spec?: Spec<T>) {
-  return makeValidator((x: string) => {
+  return makeValidator<T>((x: string) => {
     if (EMAIL_REGEX.test(x)) return x as T
     throw new EnvError(`Invalid email address: "${x}"`)
   })(spec)
 }
 
 export function host<T extends string = string>(spec?: Spec<T>) {
-  return makeValidator((input: string) => {
+  return makeValidator<T>((input: string) => {
     if (!isFQDN(input) && !isIP(input)) {
       throw new EnvError(`Invalid host (domain or ip): "${input}"`)
     }
@@ -87,7 +87,7 @@ export function host<T extends string = string>(spec?: Spec<T>) {
 }
 
 export function port<T extends number = number>(spec?: Spec<T>) {
-  return makeValidator((input: string) => {
+  return makeValidator<T>((input: string) => {
     const coerced = +input
     if (
       Number.isNaN(coerced) ||
@@ -103,7 +103,7 @@ export function port<T extends number = number>(spec?: Spec<T>) {
 }
 
 export function url<T extends string = string>(spec?: Spec<T>) {
-  return makeValidator((x: string) => {
+  return makeValidator<T>((x: string) => {
     try {
       // @ts-expect-error TS doesn't acknowledge this API by default yet
       new URL(x)


### PR DESCRIPTION
I've been having an issue where the validator spec functions (`str()`etc.) don't return the correct type when passed a generic. 

An example:

```ts
import { cleanEnv, str } from 'envalid';

type LogLevel = 'info' | 'error';

const env = cleanEnv(process.env, {
  LOG_LEVEL: str<LogLevel>(),
});
```

The return value of `cleanEnv` here is `Readonly<{ LOG_LEVEL: string } & CleanedEnvAccessors>`.

I would expect it to be `Readonly<{ LOG_LEVEL: LogLevel } & CleanedEnvAccessors>`.

If you add in a generic to `cleanEnv`, it highlights the problem further:

```ts
import { cleanEnv, str } from 'envalid';

type LogLevel = 'info' | 'error';

type Env = {
  LOG_LEVEL: LogLevel;
};

const env = cleanEnv<Env>(process.env, {
  LOG_LEVEL: str<LogLevel>(),
});
```

The line `LOG_LEVEL: str<LogLevel>()` gives a TypeScript error:

```
Type 'ValidatorSpec<string>' is not assignable to type 'ValidatorSpec<LogLevel>'.
  Type 'string' is not assignable to type 'LogLevel'.
```

So `str<LogLevel>()` is returning type `ValidatorSpec<string>` when I would expect it to return `ValidatorSpec<LogLevel>`.

This PR fixes the issue by just passing the generic type into the underlying `makeValidator` function so that the returned validator spec has the correct type.