### PR TITLE
fix: environment variables being skipped after devDefault or default value is read

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -15,9 +15,9 @@ function validateVar<T>({
   name,
   rawValue,
 }: {
-  name: string,
-  rawValue: string | T,
-  spec: ValidatorSpec<T>,
+  name: string
+  rawValue: string | T
+  spec: ValidatorSpec<T>
 }) {
   if (typeof spec._parse !== 'function') {
     throw new EnvError(`Invalid spec for "${name}"`)
@@ -73,13 +73,13 @@ export function getSanitizedEnv<T>(
         rawNodeEnv && rawNodeEnv !== 'production' && spec.hasOwnProperty('devDefault')
       if (usingDevDefault) {
         // @ts-expect-error default values can break the rules slightly by being explicitly set to undefined
-        cleanedEnv[k] = spec.devDefault;
-        break;
+        cleanedEnv[k] = spec.devDefault
+        continue
       }
       if (spec.hasOwnProperty('default')) {
         // @ts-expect-error default values can break the rules slightly by being explicitly set to undefined
-        cleanedEnv[k] = spec.default;
-        break;
+        cleanedEnv[k] = spec.default
+        continue
       }
     }
 

--- a/tests/basics.test.ts
+++ b/tests/basics.test.ts
@@ -99,6 +99,22 @@ test('devDefault and default together', () => {
   expect(prodEnv).toEqual({ FOO: 80 })
 })
 
+test('multiple devDefault', () => {
+  const env = cleanEnv(
+    { NODE_ENV: 'test' },
+    {
+      NODE_ENV: str({ choices: ['development', 'test', 'production'], devDefault: 'development' }),
+      RUNTIME_ENV: str({
+        choices: ['local', 'staging', 'production'],
+        devDefault: 'local',
+      }),
+      SUBDOMAIN: str({ devDefault: 'envalid' }),
+    },
+  )
+
+  expect(env.SUBDOMAIN).toBe('envalid')
+})
+
 test('choices field', () => {
   // Throws when the env var isn't in the given choices:
   const spec = {


### PR DESCRIPTION
Hello, and thank you for this amazing library!

I encountered a bug when a config object has values after one has had an environment value with a `devDefault` property set. (See the added test case)

This PR fixes it by changing the `break` clauses to `continue` so we still loop through the rest of the keys.



