### PR TITLE
Add an "error mode" option

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -102,6 +102,6 @@ export function getSanitizedEnv<T>(
   }
 
   const reporter = options?.reporter || defaultReporter
-  reporter({ errors, env: cleanedEnv })
+  reporter({ errors, env: cleanedEnv, errorMode: options.errorMode })
   return cleanedEnv
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,8 +53,22 @@ export interface CleanedEnvAccessors {
   readonly isProd: boolean
 }
 
+export enum ErrorMode {
+  THROW = "throw",
+  EXIT = "exit"
+}
+
+// Custom error that can be differentiated from other generic 'Error' instances with
+// the 'instanceof' operator.
+export class EnvalidError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 export interface ReporterOptions<T> {
   errors: Partial<Record<keyof T, Error>>
+  errorMode?: ErrorMode
   env: unknown
 }
 
@@ -64,4 +78,6 @@ export interface CleanOptions<T> {
    * See ./reporter.ts for the default implementation.
    */
   reporter?: ((opts: ReporterOptions<T>) => void) | null
+  errorMode?: ErrorMode
 }
+

--- a/tests/reporter.test.ts
+++ b/tests/reporter.test.ts
@@ -1,6 +1,7 @@
 import { defaultReporter as mainReporterExport } from '../src'
 import { defaultReporter } from '../src/reporter'
 import { EnvError, EnvMissingError } from '../src/errors'
+import { ErrorMode } from '../src/types'
 
 let logger: jest.MockedFunction<any>
 let exitSpy: jest.SpyInstance | null = null
@@ -88,5 +89,25 @@ describe('default reporter', () => {
     )
     expect(logger).toHaveBeenCalledTimes(0)
     expect(exitSpy).toHaveBeenCalledTimes(0)
+  })
+
+  test.only('errorMode = throw makes the reporter throw an error', () => {
+    const action = () => defaultReporter(
+      {
+        errors: { FOO: new EnvMissingError() },
+        env: {},
+      },
+      { logger, errorMode: ErrorMode.THROW },
+    )
+
+    expect(action).toThrowError("Invalid environment variables.");
+    expect(exitSpy).toHaveBeenCalledTimes(0)
+    expect(logger).toHaveBeenCalledTimes(1)
+
+    const output = logger?.mock?.calls?.[0]?.[0]
+    expect(output).toMatch(/Missing\S+ environment variables:/)
+    expect(output).toMatch(/FOO\S+/)
+    expect(output).toMatch('(required)')
+    expect(output).not.toMatch(/Invalid\S+ environment variables:/)
   })
 })


### PR DESCRIPTION
This option allows users to decide how errors should be treated by envalid: either `throw` or `exit` the process.

I wanted to be able to handle the errors from envalid but unfortunately we currently don't have the choice: it's `process.exit(1)` all the time which bypasses the rest of the code and all `catch` blocks.

This preserves the default behavior of `exit()`ing on errors but gives the possibility to have the library `throw()` instead. The error message is up for debate. I kept it very simple.