### PR TITLE
Add `nuxt-envalid` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ Since by default envalid's output is wrapped in a Proxy, structuredClone [will n
 
 * [nestjs-envalid](https://github.com/cobraz/nestjs-envalid) is a wrapper for using Envalid with [NestJS](https://nestjs.com/)
 
+* [nuxt-envalid](https://github.com/manuelhenke/nuxt-envalid) is a wrapper for using Envalid with [NuxtJS](https://nuxtjs.org/)
+
 
 ## Motivation
 


### PR DESCRIPTION
Hello, I've just made a wrapper module for `nuxtjs`. 

I also initiated to get it added to the official modules overview: https://github.com/nuxt/modules/issues/426