### PR TITLE
Fix BaseValidator typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -74,9 +74,9 @@ export interface BaseValidator<BaseT> {
   // These function overloads enable nuanced type inferences for optimal DX
   // This will prevent specifying "default" alone from narrowing down output type.
   // https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads
+  <T extends BaseT>(spec: OptionalSpec<T>): OptionalValidatorSpec<T>
   (spec: ChoicelessRequiredSpecWithType<BaseT>): RequiredValidatorSpec<BaseT>
   <T extends BaseT>(spec?: RequiredSpec<T>): RequiredValidatorSpec<T>
-  <T extends BaseT>(spec: OptionalSpec<T>): OptionalValidatorSpec<T>
 }
 
 // Such validator inputs a structured input format such as JSON.

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -78,6 +78,12 @@ describe('validators types', () => {
     expectTypeOf(validator()).toEqualTypeOf<RequiredValidatorSpec<number>>()
     expectTypeOf(validator<1>()).toEqualTypeOf<RequiredValidatorSpec<1>>()
     expectTypeOf(validator({ default: undefined })).toEqualTypeOf<OptionalValidatorSpec<number>>()
+    expectTypeOf(validator({ default: undefined, desc: '' })).toEqualTypeOf<
+      OptionalValidatorSpec<number>
+    >()
+    expectTypeOf(validator({ default: undefined, devDefault: undefined })).toEqualTypeOf<
+      OptionalValidatorSpec<number>
+    >()
     expectTypeOf(validator({ devDefault: undefined })).toEqualTypeOf<
       RequiredValidatorSpec<number>
     >()
@@ -127,7 +133,12 @@ describe('validators types', () => {
     expectTypeOf(validator({ devDefault: undefined })).toEqualTypeOf<
       RequiredValidatorSpec<string>
     >()
-
+    expectTypeOf(validator({ default: undefined, desc: '' })).toEqualTypeOf<
+      OptionalValidatorSpec<string>
+    >()
+    expectTypeOf(validator({ default: undefined, devDefault: undefined })).toEqualTypeOf<
+      OptionalValidatorSpec<string>
+    >()
     expectTypeOf(validator({ default: undefined })).toEqualTypeOf<OptionalValidatorSpec<string>>()
     expectTypeOf(validator({ devDefault: undefined })).toEqualTypeOf<
       RequiredValidatorSpec<string>
@@ -152,6 +163,12 @@ describe('validators types', () => {
     expectTypeOf(validator()).toEqualTypeOf<RequiredValidatorSpec<any>>()
     expectTypeOf(validator({ default: {} as any })).toEqualTypeOf<RequiredValidatorSpec<any>>()
     expectTypeOf(validator({ default: undefined })).toEqualTypeOf<OptionalValidatorSpec<any>>()
+    expectTypeOf(validator({ default: undefined, desc: '' })).toEqualTypeOf<
+      OptionalValidatorSpec<any>
+    >()
+    expectTypeOf(validator({ default: undefined, devDefault: undefined })).toEqualTypeOf<
+      OptionalValidatorSpec<any>
+    >()
     //@ts-expect-error - Choices not available for structured data
     validator({ choices: [{ foo: 'bar' }] })
     expectTypeOf(validator({ devDefault: undefined })).toEqualTypeOf<RequiredValidatorSpec<any>>()


### PR DESCRIPTION
@af This is a small follow-up PR on #194. After testing in our codebase, I noticed that this:

```ts
const result = cleanEnv(process.env, {
  FOO: str({
    default: undefined,
    desc: "",
  }),
});
```

Would resolve to:
![image](https://user-images.githubusercontent.com/3646758/205493158-a4f94cbd-9f56-47f8-875b-12c200989520.png)

After this patch, it resolves to:

![image](https://user-images.githubusercontent.com/3646758/205493193-700f8372-06d0-44ce-801d-0dc5c9a516fb.png)


The order of `BaseValidator` overrides was wrong; the optional spec should come first.