### PR TITLE
Allow support for extra inspectables

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,11 @@
 import { CleanedEnvAccessors, StrictProxyMiddlewareOptions } from './types'
 
-export const strictProxyMiddleware = <T extends object>(envObj: T, rawEnv: unknown, options: StrictProxyMiddlewareOptions = {}) => {
-  const { extraInspectables = [] } = options;
+export const strictProxyMiddleware = <T extends object>(
+  envObj: T,
+  rawEnv: unknown,
+  options: StrictProxyMiddlewareOptions = {},
+) => {
+  const { extraInspectables = [] } = options
   const inspectables = [
     'length',
     'inspect',
@@ -30,7 +34,11 @@ export const strictProxyMiddleware = <T extends object>(envObj: T, rawEnv: unkno
       // proxy that throws crashes the entire process. This permits access on
       // the necessary properties for `console.log(envObj)`, `envObj.length`,
       // `envObj.hasOwnProperty('string')` to work.
-      if (inspectables.includes(name) || inspectSymbolStrings.includes(name.toString()) || extraInspectables.includes(name)) {
+      if (
+        inspectables.includes(name) ||
+        inspectSymbolStrings.includes(name.toString()) ||
+        extraInspectables.includes(name)
+      ) {
         // @ts-expect-error TS doesn't like symbol types as indexers
         return target[name]
       }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
-import { CleanedEnvAccessors } from './types'
+import { CleanedEnvAccessors, StrictProxyMiddlewareOptions } from './types'
 
-export const strictProxyMiddleware = <T extends object>(envObj: T, rawEnv: unknown) => {
+export const strictProxyMiddleware = <T extends object>(envObj: T, rawEnv: unknown, options: StrictProxyMiddlewareOptions = {}) => {
+  const { extraInspectables = [] } = options;
   const inspectables = [
     'length',
     'inspect',
@@ -29,7 +30,7 @@ export const strictProxyMiddleware = <T extends object>(envObj: T, rawEnv: unkno
       // proxy that throws crashes the entire process. This permits access on
       // the necessary properties for `console.log(envObj)`, `envObj.length`,
       // `envObj.hasOwnProperty('string')` to work.
-      if (inspectables.includes(name) || inspectSymbolStrings.includes(name.toString())) {
+      if (inspectables.includes(name) || inspectSymbolStrings.includes(name.toString()) || extraInspectables.includes(name)) {
         // @ts-expect-error TS doesn't like symbol types as indexers
         return target[name]
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,3 +136,12 @@ export interface CleanOptions<T> {
    */
   reporter?: ((opts: ReporterOptions<T>) => void) | null
 }
+
+export interface StrictProxyMiddlewareOptions {
+  /**
+   * A list of extra inspectable properties to add to the middleware.
+   * 
+   * This is useful if you want to add support for framework-specific values.
+   */
+  extraInspectables?: string[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,8 +140,8 @@ export interface CleanOptions<T> {
 export interface StrictProxyMiddlewareOptions {
   /**
    * A list of extra inspectable properties to add to the middleware.
-   * 
+   *
    * This is useful if you want to add support for framework-specific values.
    */
-  extraInspectables?: string[];
+  extraInspectables?: string[]
 }

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,5 +1,5 @@
 import { cleanEnv, customCleanEnv, str } from '../src'
-import { accessorMiddleware } from '../src/middleware'
+import { accessorMiddleware, strictProxyMiddleware } from '../src/middleware'
 
 describe('customCleanEnv middleware type inference', () => {
   test('allows access to properties on the output object', () => {
@@ -156,5 +156,19 @@ describe('proxy middleware', () => {
 
     expect(() => JSON.stringify(env)).not.toThrow()
     expect(JSON.stringify(env)).toEqual('{"FOO":"foo"}')
+  })
+})
+
+describe('strictProxyMiddleware', () => {
+  test('proxy allows extra inspectables applied through options', () => {
+    const env = customCleanEnv(
+      { FOO: 'bar' },
+      { FOO: str() },
+      (cleaned, raw) =>
+        strictProxyMiddleware(cleaned, raw, { extraInspectables: ['hello'] })
+    )
+
+    // @ts-expect-error This invalid usage should trigger a type error
+    expect(() => env.hello).not.toThrow()
   })
 })

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -161,11 +161,8 @@ describe('proxy middleware', () => {
 
 describe('strictProxyMiddleware', () => {
   test('proxy allows extra inspectables applied through options', () => {
-    const env = customCleanEnv(
-      { FOO: 'bar' },
-      { FOO: str() },
-      (cleaned, raw) =>
-        strictProxyMiddleware(cleaned, raw, { extraInspectables: ['hello'] })
+    const env = customCleanEnv({ FOO: 'bar' }, { FOO: str() }, (cleaned, raw) =>
+      strictProxyMiddleware(cleaned, raw, { extraInspectables: ['hello'] }),
     )
 
     // @ts-expect-error This invalid usage should trigger a type error


### PR DESCRIPTION
I was looking for a less boilerplate way to do what is described in #142. I feel like the extra inspectable array option is the way to go.

This will also make removing the custom middleware defined in `nestjs-envalid` possible.