### PR TITLE
Handle "yes" and "no" as valid boolean type

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ URL, email address). To these ends, the following validation functions are avail
 - `str()` - Passes string values through, will ensure a value is present unless a
   `default` value is given. Note that an empty string is considered a valid value -
   if this is undesirable you can easily create your own validator (see below)
-- `bool()` - Parses env var strings `"1", "0", "true", "false", "t", "f", "yes", "no"` into booleans
+- `bool()` - Parses env var strings `"1", "0", "true", "false", "t", "f", "yes", "no", "on", "off"` into booleans
 - `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number
 - `email()` - Ensures an env var is an email address
 - `host()` - Ensures an env var is either a domain name or an ip address (v4 or v6)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ URL, email address). To these ends, the following validation functions are avail
 - `str()` - Passes string values through, will ensure a value is present unless a
   `default` value is given. Note that an empty string is considered a valid value -
   if this is undesirable you can easily create your own validator (see below)
-- `bool()` - Parses env var strings `"1", "0", "true", "false", "t", "f"` into booleans
+- `bool()` - Parses env var strings `"1", "0", "true", "false", "t", "f", "yes", "no"` into booleans
 - `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number
 - `email()` - Ensures an env var is an email address
 - `host()` - Ensures an env var is either a domain name or an ip address (v4 or v6)

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -34,11 +34,13 @@ export const bool = makeExactValidator<boolean>((input: string | boolean) => {
     case true:
     case 'true':
     case 't':
+    case 'yes':
     case '1':
       return true
     case false:
     case 'false':
     case 'f':
+    case 'no':
     case '0':
       return false
     default:

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -35,12 +35,14 @@ export const bool = makeExactValidator<boolean>((input: string | boolean) => {
     case 'true':
     case 't':
     case 'yes':
+    case 'on':
     case '1':
       return true
     case false:
     case 'false':
     case 'f':
     case 'no':
+    case 'off':
     case '0':
       return false
     default:

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -33,6 +33,11 @@ test('bool() works with various formats', () => {
   const no = cleanEnv({ FOO: 'no' }, { FOO: bool() })
   expect(no).toEqual({ FOO: false })
 
+  const on = cleanEnv({ FOO: 'on'}, { FOO: bool() })
+  expect(on).toEqual({ FOO: true })
+  const off = cleanEnv({ FOO: 'off' }, { FOO: bool() })
+  expect(off).toEqual({ FOO: false })
+
   const defaultF = cleanEnv({}, { FOO: bool({ default: false }) })
   expect(defaultF).toEqual({ FOO: false })
 })

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -28,6 +28,11 @@ test('bool() works with various formats', () => {
   const f = cleanEnv({ FOO: 'f' }, { FOO: bool() })
   expect(f).toEqual({ FOO: false })
 
+  const yes = cleanEnv({ FOO: 'yes'}, { FOO: bool() })
+  expect(yes).toEqual({ FOO: true })
+  const no = cleanEnv({ FOO: 'no' }, { FOO: bool() })
+  expect(no).toEqual({ FOO: false })
+
   const defaultF = cleanEnv({}, { FOO: bool({ default: false }) })
   expect(defaultF).toEqual({ FOO: false })
 })


### PR DESCRIPTION
I propose to give the opportunity to set Boolean values ​​also using `yes` and `no`.