### PR TITLE
Add support for config.isStaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ env.ADMIN_EMAIL // -> 'admin@example.com'
 // Envalid checks for NODE_ENV automatically, and provides the following
 // shortcut (boolean) properties for checking its value:
 env.isProduction // true if NODE_ENV === 'production'
+env.isProd // true if NODE_ENV === 'production'
+env.isStaging // true if NODE_ENV === 'staging'
 env.isTest // true if NODE_ENV === 'test'
+env.isDevelopment // true if NODE_ENV === 'development'
 env.isDev // true if NODE_ENV === 'development'
 ```
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,7 +64,7 @@ export const strictProxyMiddleware = <T extends object>(
 }
 
 export const accessorMiddleware = <T>(envObj: T, rawEnv: unknown) => {
-  // Attach is{Prod/Dev/Test} properties for more readable NODE_ENV checks
+  // Attach is{Prod/Stage/Dev/Test} properties for more readable NODE_ENV checks
   // Note that isDev and isProd are just aliases to isDevelopment and isProduction
 
   // @ts-ignore attempt to read NODE_ENV even if it's not in the spec
@@ -76,6 +76,8 @@ export const accessorMiddleware = <T>(envObj: T, rawEnv: unknown) => {
   Object.defineProperties(envObj, {
     isDevelopment: { value: computedNodeEnv === 'development' },
     isDev: { value: computedNodeEnv === 'development' },
+    isStaging: { value: computedNodeEnv === 'staging' },
+    isStage: { value: computedNodeEnv === 'staging' },
     isProduction: { value: isProd },
     isProd: { value: isProd },
     isTest: { value: computedNodeEnv === 'test' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,10 @@ export interface CleanedEnvAccessors {
   /** true if NODE_ENV === 'test' */
   readonly isTest: boolean
 
+  /** true if NODE_ENV === 'staging' */
+  readonly isStaging: boolean
+  readonly isStage: boolean
+
   /** true if NODE_ENV === 'production' */
   readonly isProduction: boolean
   readonly isProd: boolean

--- a/tests/basics.test.ts
+++ b/tests/basics.test.ts
@@ -168,10 +168,11 @@ describe('NODE_ENV built-in support', () => {
   // (this was changed in v7). You need to create your own NODE_ENV validation if you want this to
   // happen.
   //
-  // The isProduction/isTest/isDev properties are still supported out of the box for
-  // 'production'/'test'/'development', respectively
+  // The isProduction/isStaging/isTest/isDev properties are still supported out of the box for
+  // 'production'/'staging'/'test'/'development', respectively
   test('no longer validates NODE_ENV by default', () => {
     expect(cleanEnv({ NODE_ENV: 'production' }, {})).toEqual({})
+    expect(cleanEnv({ NODE_ENV: 'staging' }, {})).toEqual({})
     expect(cleanEnv({ NODE_ENV: 'development' }, {})).toEqual({})
     expect(cleanEnv({ NODE_ENV: 'test' }, {})).toEqual({})
 
@@ -193,6 +194,8 @@ describe('NODE_ENV built-in support', () => {
   test('accessor helpers via middleware work as expected', () => {
     expect(cleanEnv({ NODE_ENV: 'production' }, {}).isProduction).toEqual(true)
     expect(cleanEnv({ NODE_ENV: 'production' }, {}).isProd).toEqual(true)
+    expect(cleanEnv({ NODE_ENV: 'staging' }, {}).isStaging).toEqual(true)
+    expect(cleanEnv({ NODE_ENV: 'staging' }, {}).isStage).toEqual(true)
     expect(cleanEnv({ NODE_ENV: 'test' }, {}).isTest).toEqual(true)
     expect(cleanEnv({ NODE_ENV: 'development' }, {}).isDev).toEqual(true)
     expect(cleanEnv({ NODE_ENV: 'development' }, {}).isDevelopment).toEqual(true)
@@ -200,6 +203,8 @@ describe('NODE_ENV built-in support', () => {
     // assume production if NODE_ENV is not specified:
     expect(cleanEnv({}, {}).isProduction).toEqual(true)
     expect(cleanEnv({}, {}).isProd).toEqual(true)
+    expect(cleanEnv({}, {}).isStage).toEqual(false)
+    expect(cleanEnv({}, {}).isStaging).toEqual(false)
     expect(cleanEnv({}, {}).isDev).toEqual(false)
     expect(cleanEnv({}, {}).isDevelopment).toEqual(false)
     expect(cleanEnv({}, {}).isTest).toEqual(false)
@@ -208,6 +213,8 @@ describe('NODE_ENV built-in support', () => {
     const unsetEnv = cleanEnv({ NODE_ENV: '' }, {})
     expect(unsetEnv.isProduction).toEqual(true)
     expect(unsetEnv.isProd).toEqual(true)
+    expect(unsetEnv.isStaging).toEqual(false)
+    expect(unsetEnv.isStage).toEqual(false)
     expect(unsetEnv.isDev).toEqual(false)
     expect(unsetEnv.isDevelopment).toEqual(false)
   })
@@ -219,6 +226,8 @@ describe('NODE_ENV built-in support', () => {
     expect(cleanEnv({}, customSpec)).toEqual({ NODE_ENV: 'FOO' })
     expect(cleanEnv({}, customSpec).isProduction).toEqual(false)
     expect(cleanEnv({}, customSpec).isProd).toEqual(false)
+    expect(cleanEnv({}, customSpec).isStaging).toEqual(false)
+    expect(cleanEnv({}, customSpec).isStage).toEqual(false)
     expect(cleanEnv({}, customSpec).isDev).toEqual(false)
     expect(cleanEnv({}, customSpec).isDevelopment).toEqual(false)
   })
@@ -241,6 +250,9 @@ test('testOnly', () => {
 
   process.env.NODE_ENV = 'production'
   expect(() => cleanEnv({ NODE_ENV: 'production' }, makeSpec(), makeSilent)).toThrow()
+
+  process.env.NODE_ENV = 'staging'
+  expect(() => cleanEnv({ NODE_ENV: 'staging' }, makeSpec(), makeSilent)).toThrow()
 
   process.env.NODE_ENV = 'development'
   expect(() => cleanEnv({ NODE_ENV: 'development' }, makeSpec(), makeSilent)).toThrow()


### PR DESCRIPTION
## Motivation

We have a use case where we have a check to enable rate limiter in non-development environment, 
and at the same time disable the Redoc Open API documentation in staging environment.

**TL;DR:** We have a use case where we want to be able to explicitly check for staging environment.

## Changes

```
const config = cleanEnv({ NODE_ENV: 'staging' }, {})

config.isStage // true
config.isStaging // true
```

Similar issues: 
- #73 