### PR TITLE
feat(#251)!: treat empty strings as missing environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ Node's `process.env` only stores strings, but sometimes you want to retrieve oth
 URL, email address). To these ends, the following validation functions are available:
 
 - `str()` - Passes string values through, will ensure a value is present unless a
-  `default` value is given. Note that an empty string is considered a valid value -
-  if this is undesirable you can easily create your own validator (see below)
+  `default` value is given. Note that an empty string is not considered a valid value
 - `bool()` - Parses env var strings `"1", "0", "true", "false", "t", "f", "yes", "no", "on", "off"` into booleans
 - `num()` - Parses an env var (eg. `"42", "0.23", "1e5"`) into a Number
 - `email()` - Ensures an env var is an email address

--- a/src/core.ts
+++ b/src/core.ts
@@ -11,16 +11,16 @@ import type { CleanOptions, Spec, SpecsOutput, ValidatorSpec } from './types'
 function validateVar<T>({
   spec,
   name,
-  normalizedValue,
+  rawValue,
 }: {
   name: string
-  normalizedValue: string | T
+  rawValue: string | T
   spec: ValidatorSpec<T>
 }) {
   if (typeof spec._parse !== 'function') {
     throw new EnvError(`Invalid spec for "${name}"`)
   }
-  const value = spec._parse(normalizedValue as string)
+  const value = spec._parse(rawValue as string)
 
   if (spec.choices) {
     if (!Array.isArray(spec.choices)) {
@@ -40,7 +40,7 @@ export function formatSpecDescription<T>(spec: Spec<T>) {
   return `${spec.desc}${egText}${docsText}`
 }
 
-const readNormalizedEnvValue = <T>(
+const readRawEnvValue = <T>(
   env: unknown,
   k: keyof T | 'NODE_ENV',
 ): string | undefined | T[keyof T] => {
@@ -65,16 +65,16 @@ export function getSanitizedEnv<S>(
   const castedSpecs = specs as unknown as Record<keyof S, ValidatorSpec<unknown>>
   const errors = {} as Record<keyof S, Error>
   const varKeys = Object.keys(castedSpecs) as Array<keyof S>
-  const normalizedNodeEnv = readNormalizedEnvValue(environment, 'NODE_ENV')
+  const normalizedNodeEnv = readRawEnvValue(environment, 'NODE_ENV')
 
   for (const k of varKeys) {
     const spec = castedSpecs[k]
-    const normalizedValue = readNormalizedEnvValue(environment, k)
+    const rawValue = readRawEnvValue(environment, k)
 
     try {
       // If no value was given and default/devDefault/testDefault were provided, return the
       // appropriate default value without passing it through validation
-      if (normalizedValue === undefined) {
+      if (rawValue === undefined) {
         // Use testDefault only when NODE_ENV is 'test'. Takes priority over devDefault and default.
         if (normalizedNodeEnv === 'test' && Object.hasOwn(spec, 'testDefault')) {
           cleanedEnv[k] = spec.testDefault
@@ -102,7 +102,7 @@ export function getSanitizedEnv<S>(
         throw new EnvMissingError(formatSpecDescription(spec))
       }
 
-      cleanedEnv[k] = validateVar({ name: k as string, spec, normalizedValue })
+      cleanedEnv[k] = validateVar({ name: k as string, spec, rawValue })
     } catch (err) {
       if (options?.reporter === null) throw err
       if (err instanceof Error) errors[k] = err

--- a/src/core.ts
+++ b/src/core.ts
@@ -65,7 +65,7 @@ export function getSanitizedEnv<S>(
   const castedSpecs = specs as unknown as Record<keyof S, ValidatorSpec<unknown>>
   const errors = {} as Record<keyof S, Error>
   const varKeys = Object.keys(castedSpecs) as Array<keyof S>
-  const normalizedNodeEnv = readRawEnvValue(environment, 'NODE_ENV')
+  const rawNodeEnv = readRawEnvValue(environment, 'NODE_ENV')
 
   for (const k of varKeys) {
     const spec = castedSpecs[k]
@@ -76,16 +76,14 @@ export function getSanitizedEnv<S>(
       // appropriate default value without passing it through validation
       if (rawValue === undefined) {
         // Use testDefault only when NODE_ENV is 'test'. Takes priority over devDefault and default.
-        if (normalizedNodeEnv === 'test' && Object.hasOwn(spec, 'testDefault')) {
+        if (rawNodeEnv === 'test' && Object.hasOwn(spec, 'testDefault')) {
           cleanedEnv[k] = spec.testDefault
           continue
         }
 
         // Use devDefault values only if NODE_ENV was explicitly set, and isn't 'production'
         const usingDevDefault =
-          normalizedNodeEnv &&
-          normalizedNodeEnv !== 'production' &&
-          Object.hasOwn(spec, 'devDefault')
+          rawNodeEnv && rawNodeEnv !== 'production' && Object.hasOwn(spec, 'devDefault')
 
         if (usingDevDefault) {
           cleanedEnv[k] = spec.devDefault

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,6 +1,6 @@
 import { EnvError, EnvMissingError } from './errors'
-import type { CleanOptions, SpecsOutput, Spec, ValidatorSpec } from './types'
 import { defaultReporter } from './reporter'
+import type { CleanOptions, Spec, SpecsOutput, ValidatorSpec } from './types'
 
 /**
  * Validate a single env var, given a spec object
@@ -11,16 +11,16 @@ import { defaultReporter } from './reporter'
 function validateVar<T>({
   spec,
   name,
-  rawValue,
+  normalizedValue,
 }: {
   name: string
-  rawValue: string | T
+  normalizedValue: string | T
   spec: ValidatorSpec<T>
 }) {
   if (typeof spec._parse !== 'function') {
     throw new EnvError(`Invalid spec for "${name}"`)
   }
-  const value = spec._parse(rawValue as string)
+  const value = spec._parse(normalizedValue as string)
 
   if (spec.choices) {
     if (!Array.isArray(spec.choices)) {
@@ -40,8 +40,17 @@ export function formatSpecDescription<T>(spec: Spec<T>) {
   return `${spec.desc}${egText}${docsText}`
 }
 
-const readRawEnvValue = <T>(env: unknown, k: keyof T | 'NODE_ENV'): string | T[keyof T] => {
-  return (env as any)[k]
+const readNormalizedEnvValue = <T>(
+  env: unknown,
+  k: keyof T | 'NODE_ENV',
+): string | undefined | T[keyof T] => {
+  const result = (env as any)[k]
+
+  if (typeof result == 'string' && !result.trim()) {
+    return undefined
+  }
+
+  return result
 }
 
 /**
@@ -56,25 +65,27 @@ export function getSanitizedEnv<S>(
   const castedSpecs = specs as unknown as Record<keyof S, ValidatorSpec<unknown>>
   const errors = {} as Record<keyof S, Error>
   const varKeys = Object.keys(castedSpecs) as Array<keyof S>
-  const rawNodeEnv = readRawEnvValue(environment, 'NODE_ENV')
+  const normalizedNodeEnv = readNormalizedEnvValue(environment, 'NODE_ENV')
 
   for (const k of varKeys) {
     const spec = castedSpecs[k]
-    const rawValue = readRawEnvValue(environment, k)
+    const normalizedValue = readNormalizedEnvValue(environment, k)
 
     try {
       // If no value was given and default/devDefault/testDefault were provided, return the
       // appropriate default value without passing it through validation
-      if (rawValue === undefined) {
+      if (normalizedValue === undefined) {
         // Use testDefault only when NODE_ENV is 'test'. Takes priority over devDefault and default.
-        if (rawNodeEnv === 'test' && Object.hasOwn(spec, 'testDefault')) {
+        if (normalizedNodeEnv === 'test' && Object.hasOwn(spec, 'testDefault')) {
           cleanedEnv[k] = spec.testDefault
           continue
         }
 
         // Use devDefault values only if NODE_ENV was explicitly set, and isn't 'production'
         const usingDevDefault =
-          rawNodeEnv && rawNodeEnv !== 'production' && Object.hasOwn(spec, 'devDefault')
+          normalizedNodeEnv &&
+          normalizedNodeEnv !== 'production' &&
+          Object.hasOwn(spec, 'devDefault')
 
         if (usingDevDefault) {
           cleanedEnv[k] = spec.devDefault
@@ -91,7 +102,7 @@ export function getSanitizedEnv<S>(
         throw new EnvMissingError(formatSpecDescription(spec))
       }
 
-      cleanedEnv[k] = validateVar({ name: k as string, spec, rawValue })
+      cleanedEnv[k] = validateVar({ name: k as string, spec, normalizedValue })
     } catch (err) {
       if (options?.reporter === null) throw err
       if (err instanceof Error) errors[k] = err

--- a/tests/requiredWhen.test.ts
+++ b/tests/requiredWhen.test.ts
@@ -2,13 +2,9 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { bool, cleanEnv, defaultReporter, EnvMissingError, num, EnvError } from '../src'
 import { formatSpecDescription } from '../src/core'
 
-const mockedDefaultReporter = <vi.Mock<typeof defaultReporter>>vi.fn()
+vi.mock('../src/reporter')
+const mockedDefaultReporter: vi.Mock = <vi.Mock<typeof defaultReporter>>defaultReporter
 mockedDefaultReporter.mockImplementation(() => {})
-
-vi.mock('../src/reporter', (): typeof import('../src/reporter') => ({
-  defaultReporter: mockedDefaultReporter,
-  envalidErrorFormatter: vi.fn(),
-}))
 
 describe('requiredWhen', () => {
   beforeEach(() => {

--- a/tests/requiredWhen.test.ts
+++ b/tests/requiredWhen.test.ts
@@ -2,9 +2,13 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { bool, cleanEnv, defaultReporter, EnvMissingError, num, EnvError } from '../src'
 import { formatSpecDescription } from '../src/core'
 
-vi.mock('../src/reporter')
-const mockedDefaultReporter: vi.Mock = <vi.Mock<typeof defaultReporter>>defaultReporter;
-mockedDefaultReporter.mockImplementation(() => { })
+const mockedDefaultReporter = <vi.Mock<typeof defaultReporter>>vi.fn()
+mockedDefaultReporter.mockImplementation(() => {})
+
+vi.mock('../src/reporter', (): typeof import('../src/reporter') => ({
+  defaultReporter: mockedDefaultReporter,
+  envalidErrorFormatter: vi.fn(),
+}))
 
 describe('requiredWhen', () => {
   beforeEach(() => {
@@ -13,7 +17,7 @@ describe('requiredWhen', () => {
   test("isn't required", () => {
     cleanEnv(
       {
-        autoExtractId: "true",
+        autoExtractId: 'true',
       },
       {
         autoExtractId: bool(),
@@ -29,14 +33,54 @@ describe('requiredWhen', () => {
         autoExtractId: true,
         id: undefined,
       },
-      errors: {}
+      errors: {},
+    })
+  })
+
+  test("isn't required but empty string provided", () => {
+    cleanEnv(
+      {
+        id: '',
+      },
+      {
+        id: num({
+          default: undefined,
+          requiredWhen: () => false,
+        }),
+      },
+    )
+    expect(mockedDefaultReporter).toHaveBeenCalledTimes(1)
+    expect(mockedDefaultReporter).toHaveBeenCalledWith({
+      env: {
+        id: undefined,
+      },
+      errors: {},
+    })
+
+    cleanEnv(
+      {
+        autoExtractId: '',
+      },
+      {
+        autoExtractId: bool({
+          default: undefined,
+          requiredWhen: () => false,
+        }),
+      },
+    )
+    expect(mockedDefaultReporter).toHaveBeenCalledTimes(2)
+    expect(mockedDefaultReporter).toHaveBeenCalledWith({
+      env: {
+        autoExtractId: undefined,
+      },
+      errors: {},
     })
   })
 
   test('required but not provided', () => {
     cleanEnv(
       {
-        autoExtractId: "false",
+        autoExtractId: 'false',
       },
       {
         autoExtractId: bool(),
@@ -68,8 +112,8 @@ describe('requiredWhen', () => {
   test('required and provided', () => {
     cleanEnv(
       {
-        autoExtractId: "false",
-        id: "123"
+        autoExtractId: 'false',
+        id: '123',
       },
       {
         autoExtractId: bool(),
@@ -92,8 +136,8 @@ describe('requiredWhen', () => {
   test('required but failed to parse', () => {
     cleanEnv(
       {
-        autoExtractId: "false",
-        id: "abc"
+        autoExtractId: 'false',
+        id: 'abc',
       },
       {
         autoExtractId: bool(),
@@ -110,7 +154,7 @@ describe('requiredWhen', () => {
         id: undefined,
       },
       errors: {
-        id: new EnvError(`Invalid number input: "abc"`)
+        id: new EnvError(`Invalid number input: "abc"`),
       },
     })
   })

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -39,8 +39,19 @@ test('bool() works with various formats', () => {
   const off = cleanEnv({ FOO: 'off' }, { FOO: bool() })
   expect(off).toEqual({ FOO: false })
 
+  expect(function withEmpty() {
+    return cleanEnv({ FOO: '' }, { FOO: bool() }, makeSilent)
+  }).toThrow()
+
   const defaultF = cleanEnv({}, { FOO: bool({ default: false }) })
   expect(defaultF).toEqual({ FOO: false })
+
+  const defaultTWithWhitespace = cleanEnv(
+    { FOO: ' ' },
+    { FOO: bool({ default: true }) },
+    makeSilent,
+  )
+  expect(defaultTWithWhitespace).toEqual({ FOO: true })
 })
 
 test('num()', () => {
@@ -132,8 +143,11 @@ test('url()', () => {
 })
 
 test('str()', () => {
-  const withEmpty = cleanEnv({ FOO: '' }, { FOO: str() })
-  expect(withEmpty).toEqual({ FOO: '' })
+  expect(cleanEnv({ FOO: 'asdf' }, { FOO: str() })).toEqual({ FOO: 'asdf' })
+
+  expect(function withWhitespace() {
+    return cleanEnv({ FOO: ' ' }, { FOO: str() }, makeSilent)
+  }).toThrow()
 
   expect(() => cleanEnv({ FOO: 42 }, { FOO: str() }, makeSilent)).toThrow()
 })

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -150,6 +150,13 @@ test('str()', () => {
   }).toThrow()
 
   expect(() => cleanEnv({ FOO: 42 }, { FOO: str() }, makeSilent)).toThrow()
+
+  const defaultWithWhitespace = cleanEnv(
+    { FOO: ' ' },
+    { FOO: str({ default: 'asdf' }) },
+    makeSilent,
+  )
+  expect(defaultWithWhitespace).toEqual({ FOO: 'asdf' })
 })
 
 test('custom types', () => {
@@ -168,11 +175,4 @@ test('custom types', () => {
   // Default values work with custom validators as well
   const withDefault = cleanEnv({}, { FOO: hex10({ default: 'abcabcabc0' }) })
   expect(withDefault).toEqual({ FOO: 'abcabcabc0' })
-
-  const defaultWithWhitespace = cleanEnv(
-    { FOO: ' ' },
-    { FOO: str({ default: 'asdf' }) },
-    makeSilent,
-  )
-  expect(defaultWithWhitespace).toEqual({ FOO: 'asdf' })
 })

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -168,4 +168,11 @@ test('custom types', () => {
   // Default values work with custom validators as well
   const withDefault = cleanEnv({}, { FOO: hex10({ default: 'abcabcabc0' }) })
   expect(withDefault).toEqual({ FOO: 'abcabcabc0' })
+
+  const defaultWithWhitespace = cleanEnv(
+    { FOO: ' ' },
+    { FOO: str({ default: "asdf" }) },
+    makeSilent,
+  )
+  expect(defaultWithWhitespace).toEqual({ FOO: "asdf" })
 })

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -171,8 +171,8 @@ test('custom types', () => {
 
   const defaultWithWhitespace = cleanEnv(
     { FOO: ' ' },
-    { FOO: str({ default: "asdf" }) },
+    { FOO: str({ default: 'asdf' }) },
     makeSilent,
   )
-  expect(defaultWithWhitespace).toEqual({ FOO: "asdf" })
+  expect(defaultWithWhitespace).toEqual({ FOO: 'asdf' })
 })

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -149,14 +149,14 @@ test('str()', () => {
     return cleanEnv({ FOO: ' ' }, { FOO: str() }, makeSilent)
   }).toThrow()
 
-  expect(() => cleanEnv({ FOO: 42 }, { FOO: str() }, makeSilent)).toThrow()
-
   const defaultWithWhitespace = cleanEnv(
     { FOO: ' ' },
     { FOO: str({ default: 'asdf' }) },
     makeSilent,
   )
   expect(defaultWithWhitespace).toEqual({ FOO: 'asdf' })
+
+  expect(() => cleanEnv({ FOO: 42 }, { FOO: str() }, makeSilent)).toThrow()
 })
 
 test('custom types', () => {


### PR DESCRIPTION
Note: Strings containing spaces are also considered missing values.